### PR TITLE
chore(cd): update rosco version to 2022.11.01.19.51.35.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -112,15 +112,15 @@ services:
       sha: 5a9aefd436c9345afcbc09958c3ef457d64fd4bc
   rosco:
     image:
-      imageId: sha256:798ed30126d52252323bf7d4b40baa981534702353897e11007a0f2ec108e744
+      imageId: sha256:b8dfddd42d5fac1c11e8d1fe12747c099e9b64d4419f9db469c6a528c9210c55
       repository: spinnaker/rosco
-      tag: 2022.10.10.17.50.51.master
+      tag: 2022.11.01.19.51.35.master
     vcs:
       repo:
         orgName: spinnaker
         repoName: rosco
         type: github
-      sha: ef1bab5e689e2542d0400027038af6442ec43f41
+      sha: 30d060397423a6e28147fec968788bed6d848437
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b8dfddd42d5fac1c11e8d1fe12747c099e9b64d4419f9db469c6a528c9210c55",
        "repository": "spinnaker/rosco",
        "tag": "2022.11.01.19.51.35.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "30d060397423a6e28147fec968788bed6d848437"
      }
    },
    "name": "rosco"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b8dfddd42d5fac1c11e8d1fe12747c099e9b64d4419f9db469c6a528c9210c55",
        "repository": "spinnaker/rosco",
        "tag": "2022.11.01.19.51.35.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "30d060397423a6e28147fec968788bed6d848437"
      }
    },
    "name": "rosco"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```