### PR TITLE
chore(cd): update armory-ext version to 2022.11.14.23.26.42.master

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -1,12 +1,12 @@
 plugins:
   armory-ext:
     image:
-      imageId: sha256:d34ea6f29026233a69433ca689f21c1975db87652a9cb7308d53837f9ed979b3
+      imageId: sha256:1532238703b35c60e17c9e901852d48f9ee22389548f6ea80ac6c697502868fb
       repository: armory/armory-ext
-      tag: 2022.10.05.16.03.46.master
+      tag: 2022.11.14.23.26.42.master
     vcs:
       repo:
         orgName: armory-plugins
         repoName: armory-ext
         type: github
-      sha: 3a0dc6c3f1fec593cd429e5ca9056d521424ff2c
+      sha: b3542328a19bd729b03d251ad921751ec4f7a8b5


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:1532238703b35c60e17c9e901852d48f9ee22389548f6ea80ac6c697502868fb",
        "repository": "armory/armory-ext",
        "tag": "2022.11.14.23.26.42.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-plugins",
          "repoName": "armory-ext",
          "type": "github"
        },
        "sha": "b3542328a19bd729b03d251ad921751ec4f7a8b5"
      }
    },
    "name": "armory-ext"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:1532238703b35c60e17c9e901852d48f9ee22389548f6ea80ac6c697502868fb",
        "repository": "armory/armory-ext",
        "tag": "2022.11.14.23.26.42.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-plugins",
          "repoName": "armory-ext",
          "type": "github"
        },
        "sha": "b3542328a19bd729b03d251ad921751ec4f7a8b5"
      }
    },
    "name": "armory-ext"
  },
  "stackFile": "plugins.yml",
  "stackPath": "plugins"
}
```