### PR TITLE
chore(cd): update spinnaker-orca version to 2022.0.0-20221124160535.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:eebbf29836488a93d3aa660cd0f4c46ae77cfa77e9347307a0bd5edefc267a45
+      repository: armory/spinnaker-orca
+      tag: 2022.0.0-20221124160535.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: 3a0f45003cf80d441c6f044606234ee4d939029d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:eebbf29836488a93d3aa660cd0f4c46ae77cfa77e9347307a0bd5edefc267a45",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221124160535.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "3a0f45003cf80d441c6f044606234ee4d939029d"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:eebbf29836488a93d3aa660cd0f4c46ae77cfa77e9347307a0bd5edefc267a45",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221124160535.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "3a0f45003cf80d441c6f044606234ee4d939029d"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```