### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221125063021.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:c499c90d9c19b449620492031275190dc913708ad304e242ae5ca8f4c3f6ad3e
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221125063021.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 4906d31ae731a1ced3976edae455b30bf77a55f3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c499c90d9c19b449620492031275190dc913708ad304e242ae5ca8f4c3f6ad3e",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221125063021.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "4906d31ae731a1ced3976edae455b30bf77a55f3"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c499c90d9c19b449620492031275190dc913708ad304e242ae5ca8f4c3f6ad3e",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221125063021.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "4906d31ae731a1ced3976edae455b30bf77a55f3"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```