### PR TITLE
chore(cd): update spinnaker-gate version to 2022.0.0-20221124155630.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:efd6cd3f782b52404aa536f2187b194204de7ee36af36e224f604c4720a576a6
+      repository: armory/spinnaker-gate
+      tag: 2022.0.0-20221124155630.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 507f0b8049db728536618bc945bc39ba674d02f0
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:efd6cd3f782b52404aa536f2187b194204de7ee36af36e224f604c4720a576a6",
        "repository": "armory/spinnaker-gate",
        "tag": "2022.0.0-20221124155630.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "507f0b8049db728536618bc945bc39ba674d02f0"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:efd6cd3f782b52404aa536f2187b194204de7ee36af36e224f604c4720a576a6",
        "repository": "armory/spinnaker-gate",
        "tag": "2022.0.0-20221124155630.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "507f0b8049db728536618bc945bc39ba674d02f0"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```