### PR TITLE
chore(cd): update spinnaker-igor version to 2022.0.0-20221124155521.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-igor:
+    image:
+      imageId: sha256:32a56b07fbe8d4416df8848ca5c9a257753eb2bef86bffa2478f2b94f4216f93
+      repository: armory/spinnaker-igor
+      tag: 2022.0.0-20221124155521.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: igor
+        type: github
+      sha: de3f1a071460b658d6e399ba671f1e5ffe8c781c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:32a56b07fbe8d4416df8848ca5c9a257753eb2bef86bffa2478f2b94f4216f93",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221124155521.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "de3f1a071460b658d6e399ba671f1e5ffe8c781c"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:32a56b07fbe8d4416df8848ca5c9a257753eb2bef86bffa2478f2b94f4216f93",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221124155521.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "de3f1a071460b658d6e399ba671f1e5ffe8c781c"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```