### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221125213333.release-1.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:616d6a3093d46b7d1b302f7e588677a09de5f8e1cdcc9eb1f8c36f439c4a89ff
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221125213333.release-1.28.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: cbe7bca56b33ff29c77329b5aabc4bd9bf234a1e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:616d6a3093d46b7d1b302f7e588677a09de5f8e1cdcc9eb1f8c36f439c4a89ff",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221125213333.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "cbe7bca56b33ff29c77329b5aabc4bd9bf234a1e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:616d6a3093d46b7d1b302f7e588677a09de5f8e1cdcc9eb1f8c36f439c4a89ff",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221125213333.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "cbe7bca56b33ff29c77329b5aabc4bd9bf234a1e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```