### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221125213358.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:d070de19c32e532d45e99fd3c7930b6a9a4073b7a56238568a22a506547c5574
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221125213358.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: c3b4ef22c917a6317fde5799533d23951845c995
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d070de19c32e532d45e99fd3c7930b6a9a4073b7a56238568a22a506547c5574",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221125213358.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "c3b4ef22c917a6317fde5799533d23951845c995"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d070de19c32e532d45e99fd3c7930b6a9a4073b7a56238568a22a506547c5574",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221125213358.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "c3b4ef22c917a6317fde5799533d23951845c995"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```