### PR TITLE
chore(cd): update spinnaker-front50 version to 2022.0.0-20221124165723.release-1.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:450e3fac60455eb9c90513a05d2debf9f58713e6fb6dd99b2780879470bdf56f
+      repository: armory/spinnaker-front50
+      tag: 2022.0.0-20221124165723.release-1.28.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 92566badb22fed15bca1eb1b4be905b4f8a9112d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:450e3fac60455eb9c90513a05d2debf9f58713e6fb6dd99b2780879470bdf56f",
        "repository": "armory/spinnaker-front50",
        "tag": "2022.0.0-20221124165723.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "92566badb22fed15bca1eb1b4be905b4f8a9112d"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:450e3fac60455eb9c90513a05d2debf9f58713e6fb6dd99b2780879470bdf56f",
        "repository": "armory/spinnaker-front50",
        "tag": "2022.0.0-20221124165723.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "92566badb22fed15bca1eb1b4be905b4f8a9112d"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```