### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221118202741.release-1.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:c820ea51a637dbb14f5d347aed01fe07b729215f487a27a79b5abadf80927045
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221118202741.release-1.27.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: b15ef986c519544c7397b0861f5b74ade1863c8c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c820ea51a637dbb14f5d347aed01fe07b729215f487a27a79b5abadf80927045",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221118202741.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b15ef986c519544c7397b0861f5b74ade1863c8c"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c820ea51a637dbb14f5d347aed01fe07b729215f487a27a79b5abadf80927045",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221118202741.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b15ef986c519544c7397b0861f5b74ade1863c8c"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```