### PR TITLE
chore(cd): update deck-armory version to 2022.11.29.01.01.39.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:dc4296e47696ef0ad199e038d958be79186cba85f5266ff17621e564dd804f0a
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2022.11.29.01.01.39.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: 4cfa3bb88e64f5fd9b2ad1ab7aa7723ebd3c8f40
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "b103ed087199aa33b83c59704f5e735f04e81244"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:dc4296e47696ef0ad199e038d958be79186cba85f5266ff17621e564dd804f0a",
        "repository": "armory/deck-armory",
        "tag": "2022.11.29.01.01.39.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "4cfa3bb88e64f5fd9b2ad1ab7aa7723ebd3c8f40"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "b103ed087199aa33b83c59704f5e735f04e81244"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:dc4296e47696ef0ad199e038d958be79186cba85f5266ff17621e564dd804f0a",
        "repository": "armory/deck-armory",
        "tag": "2022.11.29.01.01.39.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "4cfa3bb88e64f5fd9b2ad1ab7aa7723ebd3c8f40"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```