### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221129215934.release-1.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:5374f3f6bca933355ddb6cc6c8161eeab0d206b3e9211c206297497117f43b54
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221129215934.release-1.28.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: b12e1dec95691b14603f74f0b49e8fb3e942598a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5374f3f6bca933355ddb6cc6c8161eeab0d206b3e9211c206297497117f43b54",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221129215934.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b12e1dec95691b14603f74f0b49e8fb3e942598a"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5374f3f6bca933355ddb6cc6c8161eeab0d206b3e9211c206297497117f43b54",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221129215934.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b12e1dec95691b14603f74f0b49e8fb3e942598a"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```