### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221129221950.release-1.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:57967fc30b85d44a82eba8ef9a89c3dd36b3101c25dc84b08a4fe9882d6c7935
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221129221950.release-1.27.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: b1cd05549b5eb32c34c7ad8d94cf12cc9651b7d3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:57967fc30b85d44a82eba8ef9a89c3dd36b3101c25dc84b08a4fe9882d6c7935",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221129221950.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b1cd05549b5eb32c34c7ad8d94cf12cc9651b7d3"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:57967fc30b85d44a82eba8ef9a89c3dd36b3101c25dc84b08a4fe9882d6c7935",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221129221950.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b1cd05549b5eb32c34c7ad8d94cf12cc9651b7d3"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```