### PR TITLE
chore(cd): update spinnaker-echo version to 2022.0.0-20221129214750.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:8d003e9497270ed1479b2527c7dc50633cf1b1afdb34f08374b51eca95388abc
+      repository: armory/spinnaker-echo
+      tag: 2022.0.0-20221129214750.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 055ba9fe7de6db3e319ab65a265fc14f87041a10
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8d003e9497270ed1479b2527c7dc50633cf1b1afdb34f08374b51eca95388abc",
        "repository": "armory/spinnaker-echo",
        "tag": "2022.0.0-20221129214750.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "055ba9fe7de6db3e319ab65a265fc14f87041a10"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8d003e9497270ed1479b2527c7dc50633cf1b1afdb34f08374b51eca95388abc",
        "repository": "armory/spinnaker-echo",
        "tag": "2022.0.0-20221129214750.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "055ba9fe7de6db3e319ab65a265fc14f87041a10"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```