### PR TITLE
chore(cd): update spinnaker-kayenta version to 2022.0.0-20221130220344.release-1.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-kayenta:
+    image:
+      imageId: sha256:a12afb425d2d040d635484cab8d0a6783410c9bfef15a3c9747d7627d2cd44a5
+      repository: armory/spinnaker-kayenta
+      tag: 2022.0.0-20221130220344.release-1.27.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: kayenta
+        type: github
+      sha: 6c622b5cd1e15c6c2450c930c451d7fc47966575
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a12afb425d2d040d635484cab8d0a6783410c9bfef15a3c9747d7627d2cd44a5",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2022.0.0-20221130220344.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "6c622b5cd1e15c6c2450c930c451d7fc47966575"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a12afb425d2d040d635484cab8d0a6783410c9bfef15a3c9747d7627d2cd44a5",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2022.0.0-20221130220344.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "6c622b5cd1e15c6c2450c930c451d7fc47966575"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```