### PR TITLE
chore(cd): update deck-armory version to 2022.11.30.23.02.51.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:995fcf657d27ea8ab463e019d71a992bb2257824d7effdbea7649e3aba6dd991
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2022.11.30.23.02.51.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: 1c1608baa1f636e52fd0a7c27b2c49d00cda8065
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:995fcf657d27ea8ab463e019d71a992bb2257824d7effdbea7649e3aba6dd991",
        "repository": "armory/deck-armory",
        "tag": "2022.11.30.23.02.51.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "1c1608baa1f636e52fd0a7c27b2c49d00cda8065"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:995fcf657d27ea8ab463e019d71a992bb2257824d7effdbea7649e3aba6dd991",
        "repository": "armory/deck-armory",
        "tag": "2022.11.30.23.02.51.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "1c1608baa1f636e52fd0a7c27b2c49d00cda8065"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```