### PR TITLE
chore(cd): update spinnaker-front50 version to 2022.0.0-20221129214906.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:ed7745ffcee22d3ec149d7855abc5958f4d40c1dccffbea7d01ee5f93ffa9c57
+      repository: armory/spinnaker-front50
+      tag: 2022.0.0-20221129214906.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 01e19847042226fa74b67f220dcfc31f475bd449
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ed7745ffcee22d3ec149d7855abc5958f4d40c1dccffbea7d01ee5f93ffa9c57",
        "repository": "armory/spinnaker-front50",
        "tag": "2022.0.0-20221129214906.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "01e19847042226fa74b67f220dcfc31f475bd449"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ed7745ffcee22d3ec149d7855abc5958f4d40c1dccffbea7d01ee5f93ffa9c57",
        "repository": "armory/spinnaker-front50",
        "tag": "2022.0.0-20221129214906.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "01e19847042226fa74b67f220dcfc31f475bd449"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```