### PR TITLE
chore(cd): update spinnaker-gate version to 2022.0.0-20221129215145.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:ce58b725240839b73a06d8d46f2db99c5932c07dfcefb1d021919949f181c9ca
+      repository: armory/spinnaker-gate
+      tag: 2022.0.0-20221129215145.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: e63560ae12f31cc1b17a0539761d7ed09ea3ba41
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ce58b725240839b73a06d8d46f2db99c5932c07dfcefb1d021919949f181c9ca",
        "repository": "armory/spinnaker-gate",
        "tag": "2022.0.0-20221129215145.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "e63560ae12f31cc1b17a0539761d7ed09ea3ba41"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ce58b725240839b73a06d8d46f2db99c5932c07dfcefb1d021919949f181c9ca",
        "repository": "armory/spinnaker-gate",
        "tag": "2022.0.0-20221129215145.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "e63560ae12f31cc1b17a0539761d7ed09ea3ba41"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```