### PR TITLE
chore(cd): update spinnaker-igor version to 2022.0.0-20221129215213.release-1.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-igor:
+    image:
+      imageId: sha256:57cda40a9bced44e1ca773b303589bbab23a00b38c9b29db92d04689b53e573d
+      repository: armory/spinnaker-igor
+      tag: 2022.0.0-20221129215213.release-1.27.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: igor
+        type: github
+      sha: 6fa3a871011d2baa1c42cd5457b7ba5d83654e70
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:57cda40a9bced44e1ca773b303589bbab23a00b38c9b29db92d04689b53e573d",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221129215213.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "6fa3a871011d2baa1c42cd5457b7ba5d83654e70"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:57cda40a9bced44e1ca773b303589bbab23a00b38c9b29db92d04689b53e573d",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221129215213.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "6fa3a871011d2baa1c42cd5457b7ba5d83654e70"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```