### PR TITLE
chore(cd): update spinnaker-kayenta version to 2022.0.0-20221201222956.release-1.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-kayenta:
+    image:
+      imageId: sha256:e5a842b6dd8cbba2f56356f159070707270a3691ad5c8541740a5be8e90cb7f0
+      repository: armory/spinnaker-kayenta
+      tag: 2022.0.0-20221201222956.release-1.27.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: kayenta
+        type: github
+      sha: fa061cad97b941add78f1fd9fc4da0eb86f4e35b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e5a842b6dd8cbba2f56356f159070707270a3691ad5c8541740a5be8e90cb7f0",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2022.0.0-20221201222956.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "fa061cad97b941add78f1fd9fc4da0eb86f4e35b"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e5a842b6dd8cbba2f56356f159070707270a3691ad5c8541740a5be8e90cb7f0",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2022.0.0-20221201222956.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "fa061cad97b941add78f1fd9fc4da0eb86f4e35b"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```