### PR TITLE
chore(cd): update spinnaker-kayenta version to 2022.0.0-20221201223631.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-kayenta:
+    image:
+      imageId: sha256:f0c23f5b4adf477945624b4e13dd9c266d6e2a31f801dd6e5e13c390a262c337
+      repository: armory/spinnaker-kayenta
+      tag: 2022.0.0-20221201223631.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: kayenta
+        type: github
+      sha: 40701adbba9f3cfb6c485ffa75d5179a6f14e844
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f0c23f5b4adf477945624b4e13dd9c266d6e2a31f801dd6e5e13c390a262c337",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2022.0.0-20221201223631.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "40701adbba9f3cfb6c485ffa75d5179a6f14e844"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f0c23f5b4adf477945624b4e13dd9c266d6e2a31f801dd6e5e13c390a262c337",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2022.0.0-20221201223631.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "40701adbba9f3cfb6c485ffa75d5179a6f14e844"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```