### PR TITLE
chore(cd): update spinnaker-fiat version to 2022.0.0-20221206190900.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:6bbab745d191257e7fa50b1bf634f1549e40810d83d854054fe0d1cc8025e27c
+      repository: armory/spinnaker-fiat
+      tag: 2022.0.0-20221206190900.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 0282fe2bc28a1e3c829c15c0ed0260c6cd5a5618
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6bbab745d191257e7fa50b1bf634f1549e40810d83d854054fe0d1cc8025e27c",
        "repository": "armory/spinnaker-fiat",
        "tag": "2022.0.0-20221206190900.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "0282fe2bc28a1e3c829c15c0ed0260c6cd5a5618"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6bbab745d191257e7fa50b1bf634f1549e40810d83d854054fe0d1cc8025e27c",
        "repository": "armory/spinnaker-fiat",
        "tag": "2022.0.0-20221206190900.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "0282fe2bc28a1e3c829c15c0ed0260c6cd5a5618"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```