### PR TITLE
chore(cd): update spinnaker-rosco version to 2022.0.0-20221206190921.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-rosco:
+    image:
+      imageId: sha256:aad2db77959babb2ed6dc221bdbaf7070807071799a3d473075f3a89ac3c6410
+      repository: armory/spinnaker-rosco
+      tag: 2022.0.0-20221206190921.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: rosco
+        type: github
+      sha: 5dafb668deb235b73f76c6f182fcac5fec1d1229
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:aad2db77959babb2ed6dc221bdbaf7070807071799a3d473075f3a89ac3c6410",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221206190921.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "5dafb668deb235b73f76c6f182fcac5fec1d1229"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:aad2db77959babb2ed6dc221bdbaf7070807071799a3d473075f3a89ac3c6410",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221206190921.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "5dafb668deb235b73f76c6f182fcac5fec1d1229"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```