### PR TITLE
chore(cd): update spinnaker-echo version to 2022.0.0-20221206194937.release-1.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:b2e2142ce6df9147d7e0ed69b9b5a3760bd9508e979612c2c50df43fdc3caaf0
+      repository: armory/spinnaker-echo
+      tag: 2022.0.0-20221206194937.release-1.28.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 6d1e3f978764d2b1ba86963e506148353333e50b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b2e2142ce6df9147d7e0ed69b9b5a3760bd9508e979612c2c50df43fdc3caaf0",
        "repository": "armory/spinnaker-echo",
        "tag": "2022.0.0-20221206194937.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "6d1e3f978764d2b1ba86963e506148353333e50b"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b2e2142ce6df9147d7e0ed69b9b5a3760bd9508e979612c2c50df43fdc3caaf0",
        "repository": "armory/spinnaker-echo",
        "tag": "2022.0.0-20221206194937.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "6d1e3f978764d2b1ba86963e506148353333e50b"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```