### PR TITLE
chore(cd): update spinnaker-front50 version to 2022.0.0-20221206211249.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:53138f46d3d842766edc11506c7d6f36add396fffe811038e3af149a9ac51b51
+      repository: armory/spinnaker-front50
+      tag: 2022.0.0-20221206211249.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: ad068354f146108f69bb32b7ebf015b7b72eb51a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:53138f46d3d842766edc11506c7d6f36add396fffe811038e3af149a9ac51b51",
        "repository": "armory/spinnaker-front50",
        "tag": "2022.0.0-20221206211249.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ad068354f146108f69bb32b7ebf015b7b72eb51a"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:53138f46d3d842766edc11506c7d6f36add396fffe811038e3af149a9ac51b51",
        "repository": "armory/spinnaker-front50",
        "tag": "2022.0.0-20221206211249.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ad068354f146108f69bb32b7ebf015b7b72eb51a"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```