### PR TITLE
chore(cd): update spinnaker-igor version to 2022.0.0-20221206211332.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-igor:
+    image:
+      imageId: sha256:969e7bec3abc6f74951189d76170e07f3a974827353b5737f2754c2f71c9b49d
+      repository: armory/spinnaker-igor
+      tag: 2022.0.0-20221206211332.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: igor
+        type: github
+      sha: 23b170270724df7ff3c1645c461b63110fee08e7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:969e7bec3abc6f74951189d76170e07f3a974827353b5737f2754c2f71c9b49d",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221206211332.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "23b170270724df7ff3c1645c461b63110fee08e7"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:969e7bec3abc6f74951189d76170e07f3a974827353b5737f2754c2f71c9b49d",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221206211332.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "23b170270724df7ff3c1645c461b63110fee08e7"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```