### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221206213522.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:38d1df594ee806ec8fc28361ed686e3195903c5dbc76af4742a2e430fa7b5e11
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221206213522.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: dc7b626b9ea7f57c4e28849a2e1b50dbac738e20
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:38d1df594ee806ec8fc28361ed686e3195903c5dbc76af4742a2e430fa7b5e11",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221206213522.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "dc7b626b9ea7f57c4e28849a2e1b50dbac738e20"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:38d1df594ee806ec8fc28361ed686e3195903c5dbc76af4742a2e430fa7b5e11",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221206213522.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "dc7b626b9ea7f57c4e28849a2e1b50dbac738e20"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```