### PR TITLE
chore(cd): update spinnaker-orca version to 2022.0.0-20221207153554.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:ffa4aa05ae7487553f38aeb9c4363ee7f4838beaa380214185807ed3d0524d89
+      repository: armory/spinnaker-orca
+      tag: 2022.0.0-20221207153554.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: 6120da15f76bc6dc76b0f9531f64c7c76dc92aa7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ffa4aa05ae7487553f38aeb9c4363ee7f4838beaa380214185807ed3d0524d89",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221207153554.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "6120da15f76bc6dc76b0f9531f64c7c76dc92aa7"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ffa4aa05ae7487553f38aeb9c4363ee7f4838beaa380214185807ed3d0524d89",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221207153554.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "6120da15f76bc6dc76b0f9531f64c7c76dc92aa7"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```