### PR TITLE
chore(cd): update spinnaker-echo version to 2022.0.0-20221207165230.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:4e37214794a27b22edf4e61e89dd0f35335841f86815962bf3f70bc582f88189
+      repository: armory/spinnaker-echo
+      tag: 2022.0.0-20221207165230.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: d65934c17cd07464476217ee4ca086c8210b6156
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4e37214794a27b22edf4e61e89dd0f35335841f86815962bf3f70bc582f88189",
        "repository": "armory/spinnaker-echo",
        "tag": "2022.0.0-20221207165230.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "d65934c17cd07464476217ee4ca086c8210b6156"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4e37214794a27b22edf4e61e89dd0f35335841f86815962bf3f70bc582f88189",
        "repository": "armory/spinnaker-echo",
        "tag": "2022.0.0-20221207165230.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "d65934c17cd07464476217ee4ca086c8210b6156"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```