### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221207215634.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:059c3999c85a306ab749cd5e82f391061239bd444775017f7e841afa9160be23
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221207215634.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 9f3f5c6d019bd820783c348ab79efa574af17b36
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:059c3999c85a306ab749cd5e82f391061239bd444775017f7e841afa9160be23",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221207215634.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "9f3f5c6d019bd820783c348ab79efa574af17b36"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:059c3999c85a306ab749cd5e82f391061239bd444775017f7e841afa9160be23",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221207215634.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "9f3f5c6d019bd820783c348ab79efa574af17b36"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```