### PR TITLE
chore(cd): update spinnaker-fiat version to 2022.0.0-20221208143439.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:390f0de03eace11daa216da661bab7bf51726cb01df1d30a59e7f59909ec13a7
+      repository: armory/spinnaker-fiat
+      tag: 2022.0.0-20221208143439.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: b50d6210573fcdce275c4d7cd7e412be51731a1c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:390f0de03eace11daa216da661bab7bf51726cb01df1d30a59e7f59909ec13a7",
        "repository": "armory/spinnaker-fiat",
        "tag": "2022.0.0-20221208143439.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "b50d6210573fcdce275c4d7cd7e412be51731a1c"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:390f0de03eace11daa216da661bab7bf51726cb01df1d30a59e7f59909ec13a7",
        "repository": "armory/spinnaker-fiat",
        "tag": "2022.0.0-20221208143439.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "b50d6210573fcdce275c4d7cd7e412be51731a1c"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```