### PR TITLE
chore(cd): update spinnaker-rosco version to 2022.0.0-20221208143019.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-rosco:
+    image:
+      imageId: sha256:d07e0f5f493dbd261fac269454e65e1fe6ccb98d9568b46fd35536dfd7456a59
+      repository: armory/spinnaker-rosco
+      tag: 2022.0.0-20221208143019.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: rosco
+        type: github
+      sha: b0317d0dd32d0dab572e73c71cc35850274da360
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d07e0f5f493dbd261fac269454e65e1fe6ccb98d9568b46fd35536dfd7456a59",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221208143019.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "b0317d0dd32d0dab572e73c71cc35850274da360"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d07e0f5f493dbd261fac269454e65e1fe6ccb98d9568b46fd35536dfd7456a59",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221208143019.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "b0317d0dd32d0dab572e73c71cc35850274da360"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```