### PR TITLE
chore(cd): update spinnaker-kayenta version to 2022.0.0-20221208173722.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-kayenta:
+    image:
+      imageId: sha256:f551d0356fce9e31c4433a033c5a56cc72c2d59bf045d3e791b18b6197e2ef17
+      repository: armory/spinnaker-kayenta
+      tag: 2022.0.0-20221208173722.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: kayenta
+        type: github
+      sha: 65c837327cd8fe2b49dd6dd2c997cf123e901b2d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f551d0356fce9e31c4433a033c5a56cc72c2d59bf045d3e791b18b6197e2ef17",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2022.0.0-20221208173722.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "65c837327cd8fe2b49dd6dd2c997cf123e901b2d"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f551d0356fce9e31c4433a033c5a56cc72c2d59bf045d3e791b18b6197e2ef17",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2022.0.0-20221208173722.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "65c837327cd8fe2b49dd6dd2c997cf123e901b2d"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```