### PR TITLE
chore(cd): update spinnaker-rosco version to 2022.0.0-20221208211325.release-1.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-rosco:
+    image:
+      imageId: sha256:009cff6e4b903bd0b71c15475703ba4fef972f87bcfac8248edffc259e3cbd83
+      repository: armory/spinnaker-rosco
+      tag: 2022.0.0-20221208211325.release-1.27.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: rosco
+        type: github
+      sha: 713d1944fc3fd5b980d1678c46089dc54905c4f2
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:009cff6e4b903bd0b71c15475703ba4fef972f87bcfac8248edffc259e3cbd83",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221208211325.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "713d1944fc3fd5b980d1678c46089dc54905c4f2"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:009cff6e4b903bd0b71c15475703ba4fef972f87bcfac8248edffc259e3cbd83",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221208211325.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "713d1944fc3fd5b980d1678c46089dc54905c4f2"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```