### PR TITLE
chore(cd): update spinnaker-rosco version to 2022.0.0-20221208205039.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-rosco:
+    image:
+      imageId: sha256:b8dcaf8a51260e99ba7c62f12bfeb3de2c1633b973dab07846c6bdfd0b423013
+      repository: armory/spinnaker-rosco
+      tag: 2022.0.0-20221208205039.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: rosco
+        type: github
+      sha: e80cfaa1abfb3a0e9026d45d6027291bfb815daf
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b8dcaf8a51260e99ba7c62f12bfeb3de2c1633b973dab07846c6bdfd0b423013",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221208205039.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "e80cfaa1abfb3a0e9026d45d6027291bfb815daf"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b8dcaf8a51260e99ba7c62f12bfeb3de2c1633b973dab07846c6bdfd0b423013",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221208205039.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "e80cfaa1abfb3a0e9026d45d6027291bfb815daf"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```