### PR TITLE
chore(cd): update spinnaker-igor version to 2022.0.0-20221209004653.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-igor:
+    image:
+      imageId: sha256:05df3447e0e363e636724560b1e1c65dc6090be10a500927da29753a2866648b
+      repository: armory/spinnaker-igor
+      tag: 2022.0.0-20221209004653.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: igor
+        type: github
+      sha: db1fb40501c5fa5af42b8b1c863c4b91f99323ad
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:05df3447e0e363e636724560b1e1c65dc6090be10a500927da29753a2866648b",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221209004653.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "db1fb40501c5fa5af42b8b1c863c4b91f99323ad"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:05df3447e0e363e636724560b1e1c65dc6090be10a500927da29753a2866648b",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221209004653.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "db1fb40501c5fa5af42b8b1c863c4b91f99323ad"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```