### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221209012647.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:6024439bbf00888367a55b6eda5fdc501c55b97d5e5833fb34cc2bd9e7743f9c
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221209012647.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 597c6ce577bacbecd7365ef748616deb894826eb
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6024439bbf00888367a55b6eda5fdc501c55b97d5e5833fb34cc2bd9e7743f9c",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221209012647.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "597c6ce577bacbecd7365ef748616deb894826eb"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6024439bbf00888367a55b6eda5fdc501c55b97d5e5833fb34cc2bd9e7743f9c",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221209012647.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "597c6ce577bacbecd7365ef748616deb894826eb"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```