### PR TITLE
chore(cd): update spinnaker-rosco version to 2022.0.0-20221209004823.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-rosco:
+    image:
+      imageId: sha256:4d3e57677ba33d2fdcf8ec92084b60b13f36098d7026dbf030abaeff9788b67a
+      repository: armory/spinnaker-rosco
+      tag: 2022.0.0-20221209004823.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: rosco
+        type: github
+      sha: e65a68a497599ae247f0a82b760ffa57c58f59b3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4d3e57677ba33d2fdcf8ec92084b60b13f36098d7026dbf030abaeff9788b67a",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221209004823.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "e65a68a497599ae247f0a82b760ffa57c58f59b3"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4d3e57677ba33d2fdcf8ec92084b60b13f36098d7026dbf030abaeff9788b67a",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221209004823.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "e65a68a497599ae247f0a82b760ffa57c58f59b3"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```