### PR TITLE
chore(cd): update spinnaker-echo version to 2022.0.0-20221209025746.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:19cfe5781315c7fbb1e8b4209382ce7348f7059063a08916b3a3bf610f7634b0
+      repository: armory/spinnaker-echo
+      tag: 2022.0.0-20221209025746.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 04c5d363af60b3b3b16e8a43394a4f39255823ec
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:19cfe5781315c7fbb1e8b4209382ce7348f7059063a08916b3a3bf610f7634b0",
        "repository": "armory/spinnaker-echo",
        "tag": "2022.0.0-20221209025746.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "04c5d363af60b3b3b16e8a43394a4f39255823ec"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:19cfe5781315c7fbb1e8b4209382ce7348f7059063a08916b3a3bf610f7634b0",
        "repository": "armory/spinnaker-echo",
        "tag": "2022.0.0-20221209025746.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "04c5d363af60b3b3b16e8a43394a4f39255823ec"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```