### PR TITLE
chore(cd): update spinnaker-fiat version to 2022.0.0-20221209025632.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:cd246d5aadd4713630422edf09ff3af5e1c1f011de5696934054930515ed91fd
+      repository: armory/spinnaker-fiat
+      tag: 2022.0.0-20221209025632.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: e9d8cd658938b13ada3d095b302031d73c1631d3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cd246d5aadd4713630422edf09ff3af5e1c1f011de5696934054930515ed91fd",
        "repository": "armory/spinnaker-fiat",
        "tag": "2022.0.0-20221209025632.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "e9d8cd658938b13ada3d095b302031d73c1631d3"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cd246d5aadd4713630422edf09ff3af5e1c1f011de5696934054930515ed91fd",
        "repository": "armory/spinnaker-fiat",
        "tag": "2022.0.0-20221209025632.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "e9d8cd658938b13ada3d095b302031d73c1631d3"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```