### PR TITLE
chore(cd): update spinnaker-orca version to 2022.0.0-20221209030858.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:e32f33bfe422c9f7b740633452ccb928d57957ab3a46477f2c3098d911e08d75
+      repository: armory/spinnaker-orca
+      tag: 2022.0.0-20221209030858.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: b33a5d39de6ae221328e21e4755ee3d892b03267
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e32f33bfe422c9f7b740633452ccb928d57957ab3a46477f2c3098d911e08d75",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221209030858.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "b33a5d39de6ae221328e21e4755ee3d892b03267"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e32f33bfe422c9f7b740633452ccb928d57957ab3a46477f2c3098d911e08d75",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221209030858.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "b33a5d39de6ae221328e21e4755ee3d892b03267"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```