### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221209023030.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:cb288be6dd2d9f141cbc20ba7322f82814f8de851175ad3e512dde5fc235c948
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221209023030.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 907e5bff5f63ebc88132737c1199210d144bab16
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cb288be6dd2d9f141cbc20ba7322f82814f8de851175ad3e512dde5fc235c948",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221209023030.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "907e5bff5f63ebc88132737c1199210d144bab16"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cb288be6dd2d9f141cbc20ba7322f82814f8de851175ad3e512dde5fc235c948",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221209023030.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "907e5bff5f63ebc88132737c1199210d144bab16"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```