### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221209033649.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:5829d99781fcb51b7e5cb2e6d275c2848acfaba3640845149b943d1f86afcf3a
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221209033649.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: eed8a658c5b04a9719a04a0d12e070ac6340cc5c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5829d99781fcb51b7e5cb2e6d275c2848acfaba3640845149b943d1f86afcf3a",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221209033649.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "eed8a658c5b04a9719a04a0d12e070ac6340cc5c"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5829d99781fcb51b7e5cb2e6d275c2848acfaba3640845149b943d1f86afcf3a",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221209033649.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "eed8a658c5b04a9719a04a0d12e070ac6340cc5c"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```