### PR TITLE
chore(cd): update spinnaker-fiat version to 2022.0.0-20221209060032.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:586693420057ef7858c3a09abe5036b0610fe79e3056cbca3bb6b4bcb6d530bb
+      repository: armory/spinnaker-fiat
+      tag: 2022.0.0-20221209060032.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: f5c3ea15d4c30d209815196bbacf845c764869b6
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:586693420057ef7858c3a09abe5036b0610fe79e3056cbca3bb6b4bcb6d530bb",
        "repository": "armory/spinnaker-fiat",
        "tag": "2022.0.0-20221209060032.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "f5c3ea15d4c30d209815196bbacf845c764869b6"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:586693420057ef7858c3a09abe5036b0610fe79e3056cbca3bb6b4bcb6d530bb",
        "repository": "armory/spinnaker-fiat",
        "tag": "2022.0.0-20221209060032.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "f5c3ea15d4c30d209815196bbacf845c764869b6"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```