### PR TITLE
chore(cd): update spinnaker-gate version to 2022.0.0-20221209060044.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:bc5b10810462abe86bee3d418d29aa632aa77c51945bfc4c48ddad45015bcdc4
+      repository: armory/spinnaker-gate
+      tag: 2022.0.0-20221209060044.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 58407492c5a6e2ad096d6ee2547e0e9d47bcd533
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:bc5b10810462abe86bee3d418d29aa632aa77c51945bfc4c48ddad45015bcdc4",
        "repository": "armory/spinnaker-gate",
        "tag": "2022.0.0-20221209060044.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "58407492c5a6e2ad096d6ee2547e0e9d47bcd533"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:bc5b10810462abe86bee3d418d29aa632aa77c51945bfc4c48ddad45015bcdc4",
        "repository": "armory/spinnaker-gate",
        "tag": "2022.0.0-20221209060044.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "58407492c5a6e2ad096d6ee2547e0e9d47bcd533"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```