### PR TITLE
chore(cd): update spinnaker-orca version to 2022.0.0-20221209060928.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:e9c965777d13482b44ff6ef900e14ecd20142e57737d21765d8054132b822e60
+      repository: armory/spinnaker-orca
+      tag: 2022.0.0-20221209060928.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: c8c89f368052bd8344bda255c29c6cfda09f0044
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e9c965777d13482b44ff6ef900e14ecd20142e57737d21765d8054132b822e60",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221209060928.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "c8c89f368052bd8344bda255c29c6cfda09f0044"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e9c965777d13482b44ff6ef900e14ecd20142e57737d21765d8054132b822e60",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221209060928.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "c8c89f368052bd8344bda255c29c6cfda09f0044"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```