### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221209064008.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:8739a9c87f536001bfe1429ec94401d62b988643619c591b26d2f3fd63ef5751
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221209064008.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 86b312e2513d8feb67f70d1635ededcfa11dfd13
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8739a9c87f536001bfe1429ec94401d62b988643619c591b26d2f3fd63ef5751",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221209064008.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "86b312e2513d8feb67f70d1635ededcfa11dfd13"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8739a9c87f536001bfe1429ec94401d62b988643619c591b26d2f3fd63ef5751",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221209064008.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "86b312e2513d8feb67f70d1635ededcfa11dfd13"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```