### PR TITLE
chore(cd): update spinnaker-front50 version to 2022.0.0-20221209165311.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:550044319669ca7efd251ba7e05b54b6b5bbdb6429ae4cb5241b3c7d3a667785
+      repository: armory/spinnaker-front50
+      tag: 2022.0.0-20221209165311.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 1e0468ea3d72fe0a02dac1cb38400fc97ea66a39
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:550044319669ca7efd251ba7e05b54b6b5bbdb6429ae4cb5241b3c7d3a667785",
        "repository": "armory/spinnaker-front50",
        "tag": "2022.0.0-20221209165311.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "1e0468ea3d72fe0a02dac1cb38400fc97ea66a39"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:550044319669ca7efd251ba7e05b54b6b5bbdb6429ae4cb5241b3c7d3a667785",
        "repository": "armory/spinnaker-front50",
        "tag": "2022.0.0-20221209165311.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "1e0468ea3d72fe0a02dac1cb38400fc97ea66a39"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```