### PR TITLE
chore(cd): update spinnaker-igor version to 2022.0.0-20221209171649.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-igor:
+    image:
+      imageId: sha256:7ad814d9f922a7c22474f3210e4a4e8cfc8a9bf06aae72ebfb005ef2bfc95203
+      repository: armory/spinnaker-igor
+      tag: 2022.0.0-20221209171649.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: igor
+        type: github
+      sha: feae00dfe7de8833d0f4df9e842371d36948160b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7ad814d9f922a7c22474f3210e4a4e8cfc8a9bf06aae72ebfb005ef2bfc95203",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221209171649.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "feae00dfe7de8833d0f4df9e842371d36948160b"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7ad814d9f922a7c22474f3210e4a4e8cfc8a9bf06aae72ebfb005ef2bfc95203",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221209171649.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "feae00dfe7de8833d0f4df9e842371d36948160b"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```