### PR TITLE
chore(cd): update spinnaker-rosco version to 2022.0.0-20221209172705.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-rosco:
+    image:
+      imageId: sha256:06f94d159310ee0d6b9e552712c5a705611ead29c8820e9781d5d1a4eb954b6c
+      repository: armory/spinnaker-rosco
+      tag: 2022.0.0-20221209172705.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: rosco
+        type: github
+      sha: 167a31d93d82bdd749acd507e2878f37e7dbf765
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:06f94d159310ee0d6b9e552712c5a705611ead29c8820e9781d5d1a4eb954b6c",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221209172705.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "167a31d93d82bdd749acd507e2878f37e7dbf765"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:06f94d159310ee0d6b9e552712c5a705611ead29c8820e9781d5d1a4eb954b6c",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221209172705.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "167a31d93d82bdd749acd507e2878f37e7dbf765"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```