### PR TITLE
chore(cd): update spinnaker-orca version to 2022.0.0-20221209173105.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:a22653eb66892fb633b1df009553d43c8aff7b59629702629d13900cb7885615
+      repository: armory/spinnaker-orca
+      tag: 2022.0.0-20221209173105.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: 87d2bdfa7f4ce4ce5858519516c9643796ba0e78
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a22653eb66892fb633b1df009553d43c8aff7b59629702629d13900cb7885615",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221209173105.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "87d2bdfa7f4ce4ce5858519516c9643796ba0e78"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a22653eb66892fb633b1df009553d43c8aff7b59629702629d13900cb7885615",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221209173105.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "87d2bdfa7f4ce4ce5858519516c9643796ba0e78"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```