### PR TITLE
chore(cd): update spinnaker-gate version to 2022.0.0-20221209183612.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:a729fb2f27bb6514b7abcccffb79ab3d5c6b8b0ec8f2897f41e203dff78711af
+      repository: armory/spinnaker-gate
+      tag: 2022.0.0-20221209183612.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 3005eca1c6cf60cd25e237e449e471b84b8d5c51
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a729fb2f27bb6514b7abcccffb79ab3d5c6b8b0ec8f2897f41e203dff78711af",
        "repository": "armory/spinnaker-gate",
        "tag": "2022.0.0-20221209183612.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "3005eca1c6cf60cd25e237e449e471b84b8d5c51"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a729fb2f27bb6514b7abcccffb79ab3d5c6b8b0ec8f2897f41e203dff78711af",
        "repository": "armory/spinnaker-gate",
        "tag": "2022.0.0-20221209183612.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "3005eca1c6cf60cd25e237e449e471b84b8d5c51"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```