### PR TITLE
chore(cd): update spinnaker-front50 version to 2022.0.0-20221215165253.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:c8f778de13d4904318cbdd4d83e82c6b1900849b08353ec1dff2bc106dc46b44
+      repository: armory/spinnaker-front50
+      tag: 2022.0.0-20221215165253.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 5483a7e712e7832bd8a529179a61d8b1cc86dcd8
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c8f778de13d4904318cbdd4d83e82c6b1900849b08353ec1dff2bc106dc46b44",
        "repository": "armory/spinnaker-front50",
        "tag": "2022.0.0-20221215165253.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "5483a7e712e7832bd8a529179a61d8b1cc86dcd8"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c8f778de13d4904318cbdd4d83e82c6b1900849b08353ec1dff2bc106dc46b44",
        "repository": "armory/spinnaker-front50",
        "tag": "2022.0.0-20221215165253.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "5483a7e712e7832bd8a529179a61d8b1cc86dcd8"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```