### PR TITLE
chore(cd): update spinnaker-gate version to 2022.0.0-20221215165210.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:21417fd7cf432c1598955e4b8f02914ef4ac22e288cfaf607a31a2d809d9e1d6
+      repository: armory/spinnaker-gate
+      tag: 2022.0.0-20221215165210.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 4017f88e90b46f1101b637b5e21395d6c9cf58fe
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:21417fd7cf432c1598955e4b8f02914ef4ac22e288cfaf607a31a2d809d9e1d6",
        "repository": "armory/spinnaker-gate",
        "tag": "2022.0.0-20221215165210.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "4017f88e90b46f1101b637b5e21395d6c9cf58fe"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:21417fd7cf432c1598955e4b8f02914ef4ac22e288cfaf607a31a2d809d9e1d6",
        "repository": "armory/spinnaker-gate",
        "tag": "2022.0.0-20221215165210.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "4017f88e90b46f1101b637b5e21395d6c9cf58fe"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```