### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221215170220.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:b2b809cfeaf8641a998dec961930c5d32b10ef0faef7b404367059b8fa71eae7
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221215170220.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 932dd66d250fe98ff4cb783c1a6784e8e14db97c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b2b809cfeaf8641a998dec961930c5d32b10ef0faef7b404367059b8fa71eae7",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221215170220.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "932dd66d250fe98ff4cb783c1a6784e8e14db97c"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b2b809cfeaf8641a998dec961930c5d32b10ef0faef7b404367059b8fa71eae7",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221215170220.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "932dd66d250fe98ff4cb783c1a6784e8e14db97c"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```