### PR TITLE
chore(cd): update spinnaker-echo version to 2022.0.0-20221216002534.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:8890377f7e430297d75371b8a9b227de107f4f7f308db5410c46683444f2009c
+      repository: armory/spinnaker-echo
+      tag: 2022.0.0-20221216002534.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: c840d8322a27a6cc302eebbd070ed6fbeaa09626
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8890377f7e430297d75371b8a9b227de107f4f7f308db5410c46683444f2009c",
        "repository": "armory/spinnaker-echo",
        "tag": "2022.0.0-20221216002534.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "c840d8322a27a6cc302eebbd070ed6fbeaa09626"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8890377f7e430297d75371b8a9b227de107f4f7f308db5410c46683444f2009c",
        "repository": "armory/spinnaker-echo",
        "tag": "2022.0.0-20221216002534.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "c840d8322a27a6cc302eebbd070ed6fbeaa09626"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```