### PR TITLE
chore(cd): update spinnaker-orca version to 2022.0.0-20221216183602.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:7b196e256c141a0155304134e3d30bd89170531c736a6d22a30fb4f1308abac0
+      repository: armory/spinnaker-orca
+      tag: 2022.0.0-20221216183602.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: 82425b62de5ece1b2aa34f3a05c3384e86306327
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7b196e256c141a0155304134e3d30bd89170531c736a6d22a30fb4f1308abac0",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221216183602.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "82425b62de5ece1b2aa34f3a05c3384e86306327"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7b196e256c141a0155304134e3d30bd89170531c736a6d22a30fb4f1308abac0",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221216183602.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "82425b62de5ece1b2aa34f3a05c3384e86306327"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```