### PR TITLE
chore(cd): update deck-armory version to 2022.12.19.13.18.36.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:7b7ca8aaeafe3e13e28112e31b54213eb8b7809e7a3d9a0e3d2ca88d45512186
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2022.12.19.13.18.36.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: 73c09670d7b2ad87e4ae5eaa7cb9d8755fdeb19c
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "66207875f1386a3271ced770cd38227b5888c1da"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:7b7ca8aaeafe3e13e28112e31b54213eb8b7809e7a3d9a0e3d2ca88d45512186",
        "repository": "armory/deck-armory",
        "tag": "2022.12.19.13.18.36.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "73c09670d7b2ad87e4ae5eaa7cb9d8755fdeb19c"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "66207875f1386a3271ced770cd38227b5888c1da"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:7b7ca8aaeafe3e13e28112e31b54213eb8b7809e7a3d9a0e3d2ca88d45512186",
        "repository": "armory/deck-armory",
        "tag": "2022.12.19.13.18.36.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "73c09670d7b2ad87e4ae5eaa7cb9d8755fdeb19c"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```