### PR TITLE
chore(cd): update spinnaker-orca version to 2022.0.0-20221219190853.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:d422fec8909ca9a7aa791d4f8fc901c1d891a8fda813a36308694c2e322190f8
+      repository: armory/spinnaker-orca
+      tag: 2022.0.0-20221219190853.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: ff998a5fcdd21ec18a81efb6eb13954a4cd82f5e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d422fec8909ca9a7aa791d4f8fc901c1d891a8fda813a36308694c2e322190f8",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221219190853.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "ff998a5fcdd21ec18a81efb6eb13954a4cd82f5e"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d422fec8909ca9a7aa791d4f8fc901c1d891a8fda813a36308694c2e322190f8",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221219190853.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "ff998a5fcdd21ec18a81efb6eb13954a4cd82f5e"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```