### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221222003622.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:2ab8f6d20950181f65618c7cdc4bb643cf1a4bc35b2a18c8b09d3cd926bd6994
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221222003622.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: fc2ba17e445482d6eedc5c3e3f275fb0510a6cf1
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2ab8f6d20950181f65618c7cdc4bb643cf1a4bc35b2a18c8b09d3cd926bd6994",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221222003622.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "fc2ba17e445482d6eedc5c3e3f275fb0510a6cf1"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2ab8f6d20950181f65618c7cdc4bb643cf1a4bc35b2a18c8b09d3cd926bd6994",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221222003622.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "fc2ba17e445482d6eedc5c3e3f275fb0510a6cf1"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```