### PR TITLE
chore(cd): update spinnaker-igor version to 2022.0.0-20221222044813.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-igor:
+    image:
+      imageId: sha256:626da37e25a22d8814db2ee9c499dfad13102ac7284cfaaac83554241a5769ff
+      repository: armory/spinnaker-igor
+      tag: 2022.0.0-20221222044813.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: igor
+        type: github
+      sha: e3b668603e274ea6e8cba7966bcb030bb9a45e1d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:626da37e25a22d8814db2ee9c499dfad13102ac7284cfaaac83554241a5769ff",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221222044813.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "e3b668603e274ea6e8cba7966bcb030bb9a45e1d"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:626da37e25a22d8814db2ee9c499dfad13102ac7284cfaaac83554241a5769ff",
        "repository": "armory/spinnaker-igor",
        "tag": "2022.0.0-20221222044813.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "igor",
          "type": "github"
        },
        "sha": "e3b668603e274ea6e8cba7966bcb030bb9a45e1d"
      }
    },
    "name": "spinnaker-igor"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```