### PR TITLE
chore(cd): update spinnaker-rosco version to 2022.0.0-20221222044859.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-rosco:
+    image:
+      imageId: sha256:a68d1b11012c5a00954e1abb9dda73f452dbc1d1b2ea5a31618fe45f151cab76
+      repository: armory/spinnaker-rosco
+      tag: 2022.0.0-20221222044859.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: rosco
+        type: github
+      sha: ab10d9166881736a4bde10d7d3c5c164018b1a89
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a68d1b11012c5a00954e1abb9dda73f452dbc1d1b2ea5a31618fe45f151cab76",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221222044859.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "ab10d9166881736a4bde10d7d3c5c164018b1a89"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a68d1b11012c5a00954e1abb9dda73f452dbc1d1b2ea5a31618fe45f151cab76",
        "repository": "armory/spinnaker-rosco",
        "tag": "2022.0.0-20221222044859.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "ab10d9166881736a4bde10d7d3c5c164018b1a89"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```