### PR TITLE
chore(cd): update spinnaker-orca version to 2022.0.0-20221222045813.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:288b86cb0a3982b258bb93ae96747a708cf4f85c1ac4db89237668ecfae1e00b
+      repository: armory/spinnaker-orca
+      tag: 2022.0.0-20221222045813.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: 4b301bb40ca9cc1aa36d99b61ef4b6ed9ba8ad5f
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:288b86cb0a3982b258bb93ae96747a708cf4f85c1ac4db89237668ecfae1e00b",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221222045813.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "4b301bb40ca9cc1aa36d99b61ef4b6ed9ba8ad5f"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:288b86cb0a3982b258bb93ae96747a708cf4f85c1ac4db89237668ecfae1e00b",
        "repository": "armory/spinnaker-orca",
        "tag": "2022.0.0-20221222045813.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "4b301bb40ca9cc1aa36d99b61ef4b6ed9ba8ad5f"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```