### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2022.0.0-20221222052604.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:32b136c36f3d422ec2f93d74590b97cd3bb26cf272e5320e043e85c1f06e1bfa
+      repository: armory/spinnaker-clouddriver
+      tag: 2022.0.0-20221222052604.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: d7d0539e19e0853218ff8167945b1750ce5d3f2a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:32b136c36f3d422ec2f93d74590b97cd3bb26cf272e5320e043e85c1f06e1bfa",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221222052604.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "d7d0539e19e0853218ff8167945b1750ce5d3f2a"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:32b136c36f3d422ec2f93d74590b97cd3bb26cf272e5320e043e85c1f06e1bfa",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2022.0.0-20221222052604.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "d7d0539e19e0853218ff8167945b1750ce5d3f2a"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```