### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230101173855.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:aeb1fd496a0dcb6dc1b0907b807c3339e7ec318fd02934b66b4fdaed5a1cc50f
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230101173855.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 6c30c181b9f92e0f3c80c5dec547b1c20315246b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:aeb1fd496a0dcb6dc1b0907b807c3339e7ec318fd02934b66b4fdaed5a1cc50f",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230101173855.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "6c30c181b9f92e0f3c80c5dec547b1c20315246b"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:aeb1fd496a0dcb6dc1b0907b807c3339e7ec318fd02934b66b4fdaed5a1cc50f",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230101173855.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "6c30c181b9f92e0f3c80c5dec547b1c20315246b"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```