### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230104211115.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:d88d2c28158c7d120abbb1b6346b12bf6491a0417b6a668c2613e34bd427e68c
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230104211115.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 7cd8abef4ecd8e8c282f5d41827d9a087ca9658e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d88d2c28158c7d120abbb1b6346b12bf6491a0417b6a668c2613e34bd427e68c",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230104211115.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "7cd8abef4ecd8e8c282f5d41827d9a087ca9658e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d88d2c28158c7d120abbb1b6346b12bf6491a0417b6a668c2613e34bd427e68c",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230104211115.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "7cd8abef4ecd8e8c282f5d41827d9a087ca9658e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```