### PR TITLE
chore(cd): update terraformer version to 2023.01.05.15.17.47.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -123,12 +123,12 @@ services:
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
   terraformer:
     image:
-      imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a
+      imageId: sha256:d9666878e3d63ae1288afd52ea88319d9a740fb65902fd196317c54f12d6686c
       repository: armory/terraformer
-      tag: 2022.08.15.08.23.24.master
+      tag: 2023.01.05.15.17.47.master
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 06274aea2918f7e47222856537224de91c9cf542
+      sha: d5f166796bba0245068d1417a5e834c7f8511c12


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d9666878e3d63ae1288afd52ea88319d9a740fb65902fd196317c54f12d6686c",
        "repository": "armory/terraformer",
        "tag": "2023.01.05.15.17.47.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "d5f166796bba0245068d1417a5e834c7f8511c12"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d9666878e3d63ae1288afd52ea88319d9a740fb65902fd196317c54f12d6686c",
        "repository": "armory/terraformer",
        "tag": "2023.01.05.15.17.47.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "d5f166796bba0245068d1417a5e834c7f8511c12"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```