### PR TITLE
chore(cd): update deck-armory version to 2023.01.05.16.35.50.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:62b2b169c477d5c3ec0799b4f4e6655cb5abfadf772776aded9ab798d35ecbc8
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2023.01.05.16.35.50.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: 860f1c120033c581ac7b3337d5cbe07a5459dc9f
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "809475cb79ce5bc1048c362f3d440750151e71f6"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:62b2b169c477d5c3ec0799b4f4e6655cb5abfadf772776aded9ab798d35ecbc8",
        "repository": "armory/deck-armory",
        "tag": "2023.01.05.16.35.50.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "860f1c120033c581ac7b3337d5cbe07a5459dc9f"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "809475cb79ce5bc1048c362f3d440750151e71f6"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:62b2b169c477d5c3ec0799b4f4e6655cb5abfadf772776aded9ab798d35ecbc8",
        "repository": "armory/deck-armory",
        "tag": "2023.01.05.16.35.50.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "860f1c120033c581ac7b3337d5cbe07a5459dc9f"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```