### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230111184859.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:8c0eb9b23531a7f5b977b4d112b7187f1cffadc2edc6a1bdfdd9efe14eba77f6
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230111184859.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 2dc786fd4cef9ff584e9cbc0a1d94db8941ea384
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8c0eb9b23531a7f5b977b4d112b7187f1cffadc2edc6a1bdfdd9efe14eba77f6",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230111184859.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "2dc786fd4cef9ff584e9cbc0a1d94db8941ea384"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8c0eb9b23531a7f5b977b4d112b7187f1cffadc2edc6a1bdfdd9efe14eba77f6",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230111184859.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "2dc786fd4cef9ff584e9cbc0a1d94db8941ea384"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```