### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230112223021.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:b3af1795f0864293dd347af4faf71b1f821ecf2c3f32c38b42f9c24416078c73
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230112223021.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 675eacc8a13fbf37093fa5bca4a1270a4bae64d9
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b3af1795f0864293dd347af4faf71b1f821ecf2c3f32c38b42f9c24416078c73",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230112223021.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "675eacc8a13fbf37093fa5bca4a1270a4bae64d9"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b3af1795f0864293dd347af4faf71b1f821ecf2c3f32c38b42f9c24416078c73",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230112223021.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "675eacc8a13fbf37093fa5bca4a1270a4bae64d9"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```