### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230117151254.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:050b9f7c7abc2a4074f4b6ec50d716110b0c612fffec9489bb7a7133efc5a4fb
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230117151254.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 7342d04105f1c4bbe937b613738927e6c1d6b31b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:050b9f7c7abc2a4074f4b6ec50d716110b0c612fffec9489bb7a7133efc5a4fb",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230117151254.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "7342d04105f1c4bbe937b613738927e6c1d6b31b"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:050b9f7c7abc2a4074f4b6ec50d716110b0c612fffec9489bb7a7133efc5a4fb",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230117151254.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "7342d04105f1c4bbe937b613738927e6c1d6b31b"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```