### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230119185519.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:cc08e8fabc5510be3c430367e79c86eb1865f7443e08400d3d58c0d176c0a5f0
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230119185519.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 8c622d1a3983e0b7b0e3211c6ed0fa11dc37e3ee
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cc08e8fabc5510be3c430367e79c86eb1865f7443e08400d3d58c0d176c0a5f0",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230119185519.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "8c622d1a3983e0b7b0e3211c6ed0fa11dc37e3ee"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cc08e8fabc5510be3c430367e79c86eb1865f7443e08400d3d58c0d176c0a5f0",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230119185519.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "8c622d1a3983e0b7b0e3211c6ed0fa11dc37e3ee"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```