### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230120144747.release-1.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:4a7db80d2ccca65f358264eb3aa1ab672155c862a3aee9dea28a9241cc3cdafc
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230120144747.release-1.28.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 59bfbecd272bedcb73d064caa61a4592f46007fa
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4a7db80d2ccca65f358264eb3aa1ab672155c862a3aee9dea28a9241cc3cdafc",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230120144747.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "59bfbecd272bedcb73d064caa61a4592f46007fa"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4a7db80d2ccca65f358264eb3aa1ab672155c862a3aee9dea28a9241cc3cdafc",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230120144747.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "59bfbecd272bedcb73d064caa61a4592f46007fa"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```