### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230120181455.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:1804b067e1a959d7afaa2be909804fa1703a9caebf2a9022c2eaef25695beb11
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230120181455.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 98522b548581102a6db07e921c519301a9ad4bf0
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:1804b067e1a959d7afaa2be909804fa1703a9caebf2a9022c2eaef25695beb11",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230120181455.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "98522b548581102a6db07e921c519301a9ad4bf0"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:1804b067e1a959d7afaa2be909804fa1703a9caebf2a9022c2eaef25695beb11",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230120181455.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "98522b548581102a6db07e921c519301a9ad4bf0"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```