### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230120181355.release-1.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:5439e234669cd50a186152b6c65466d9242e0bbb93f0585c911f143e0276730e
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230120181355.release-1.28.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 5d41a38ed1265f7eb765c8538f4f3cd0dec39142
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5439e234669cd50a186152b6c65466d9242e0bbb93f0585c911f143e0276730e",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230120181355.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "5d41a38ed1265f7eb765c8538f4f3cd0dec39142"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5439e234669cd50a186152b6c65466d9242e0bbb93f0585c911f143e0276730e",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230120181355.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "5d41a38ed1265f7eb765c8538f4f3cd0dec39142"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```