### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230123171037.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:34823a81459ffc199ad856f86db1ff58f0feff207f191c2a198e65ad2a68e3e6
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230123171037.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 5daf7d5ca8302c3244ab967ec532e620c898af39
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:34823a81459ffc199ad856f86db1ff58f0feff207f191c2a198e65ad2a68e3e6",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230123171037.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "5daf7d5ca8302c3244ab967ec532e620c898af39"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:34823a81459ffc199ad856f86db1ff58f0feff207f191c2a198e65ad2a68e3e6",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230123171037.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "5daf7d5ca8302c3244ab967ec532e620c898af39"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```