### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230125181013.release-1.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:a486665a709db8cb9dc538ddfe3725464ef2bdec5ff2e7cc49163f77e39f7162
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230125181013.release-1.28.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 923fa4fb1a83477f1d6d08a7391b06be1fd82e9e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a486665a709db8cb9dc538ddfe3725464ef2bdec5ff2e7cc49163f77e39f7162",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230125181013.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "923fa4fb1a83477f1d6d08a7391b06be1fd82e9e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a486665a709db8cb9dc538ddfe3725464ef2bdec5ff2e7cc49163f77e39f7162",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230125181013.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "923fa4fb1a83477f1d6d08a7391b06be1fd82e9e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```