### PR TITLE
chore(cd): update spinnaker-fiat version to 2022.0.0-20221121162725.release-1.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:da800dc74b71576d54c9c9d854140c9a5ed258d0b2691145af555d189063f076
+      repository: armory/spinnaker-fiat
+      tag: 2022.0.0-20221121162725.release-1.28.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 325886ada3578827bdee6a0ecb541f7d1258806c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:da800dc74b71576d54c9c9d854140c9a5ed258d0b2691145af555d189063f076",
        "repository": "armory/spinnaker-fiat",
        "tag": "2022.0.0-20221121162725.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "325886ada3578827bdee6a0ecb541f7d1258806c"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:da800dc74b71576d54c9c9d854140c9a5ed258d0b2691145af555d189063f076",
        "repository": "armory/spinnaker-fiat",
        "tag": "2022.0.0-20221121162725.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "325886ada3578827bdee6a0ecb541f7d1258806c"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```