### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230126220236.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:9403f85779632c43544c8802d7e3e4f8615d2372c5cdf08aa9e8e00853b163c1
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230126220236.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 47b2250077508758ba0b5a24628dbb8b2a4cc7d5
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:9403f85779632c43544c8802d7e3e4f8615d2372c5cdf08aa9e8e00853b163c1",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230126220236.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "47b2250077508758ba0b5a24628dbb8b2a4cc7d5"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:9403f85779632c43544c8802d7e3e4f8615d2372c5cdf08aa9e8e00853b163c1",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230126220236.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "47b2250077508758ba0b5a24628dbb8b2a4cc7d5"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```