### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230126220202.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:6cbc5f0c7aa04d94cabf1da4daea567dcb9483858175aa5317e564c71a682168
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230126220202.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 05a2f39e7af9a93b63bb54e7bb44f0dfb82cb555
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6cbc5f0c7aa04d94cabf1da4daea567dcb9483858175aa5317e564c71a682168",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230126220202.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "05a2f39e7af9a93b63bb54e7bb44f0dfb82cb555"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6cbc5f0c7aa04d94cabf1da4daea567dcb9483858175aa5317e564c71a682168",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230126220202.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "05a2f39e7af9a93b63bb54e7bb44f0dfb82cb555"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```