### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230127002134.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:5f8a13d88872314cdf737619547320458ff62b3a53f4847ec85504e4a1833107
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230127002134.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: f593066ee800ef6cc41b404563c5273ce849c559
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5f8a13d88872314cdf737619547320458ff62b3a53f4847ec85504e4a1833107",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230127002134.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "f593066ee800ef6cc41b404563c5273ce849c559"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5f8a13d88872314cdf737619547320458ff62b3a53f4847ec85504e4a1833107",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230127002134.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "f593066ee800ef6cc41b404563c5273ce849c559"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```