### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230127174153.release-1.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:6c874d7dc86ec6c17fa98ca6ab94aefe7626d099a47c9a334d78c379197efea7
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230127174153.release-1.27.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 79ee9e88fb0d7c5aaf6565ff3128b76e71ff286e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6c874d7dc86ec6c17fa98ca6ab94aefe7626d099a47c9a334d78c379197efea7",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230127174153.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "79ee9e88fb0d7c5aaf6565ff3128b76e71ff286e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6c874d7dc86ec6c17fa98ca6ab94aefe7626d099a47c9a334d78c379197efea7",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230127174153.release-1.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "79ee9e88fb0d7c5aaf6565ff3128b76e71ff286e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```