### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230130152944.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:c0621fe7463fc1575d6ba3054ef91d9796601b926a10e4938bc751cb340e1315
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230130152944.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: af0536ffa10ba1e70c5a52a4c44af0530ed41c6b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c0621fe7463fc1575d6ba3054ef91d9796601b926a10e4938bc751cb340e1315",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230130152944.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "af0536ffa10ba1e70c5a52a4c44af0530ed41c6b"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c0621fe7463fc1575d6ba3054ef91d9796601b926a10e4938bc751cb340e1315",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230130152944.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "af0536ffa10ba1e70c5a52a4c44af0530ed41c6b"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```