### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230130152821.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:53aee1fe10333150621e41a5d810c7889cbc826d08688b063589239459a06a5a
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230130152821.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 11d0862df93d7dc4032ddc2741e447ed12e77e86
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:53aee1fe10333150621e41a5d810c7889cbc826d08688b063589239459a06a5a",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230130152821.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "11d0862df93d7dc4032ddc2741e447ed12e77e86"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:53aee1fe10333150621e41a5d810c7889cbc826d08688b063589239459a06a5a",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230130152821.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "11d0862df93d7dc4032ddc2741e447ed12e77e86"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```