### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230130162729.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:6766e94fa1586a22027d88963d2c8caa46473e3541c089ec500905d9dc4fbbca
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230130162729.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 7b7abee4f57f0b35f46e51b84d926706f99afc23
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6766e94fa1586a22027d88963d2c8caa46473e3541c089ec500905d9dc4fbbca",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230130162729.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "7b7abee4f57f0b35f46e51b84d926706f99afc23"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6766e94fa1586a22027d88963d2c8caa46473e3541c089ec500905d9dc4fbbca",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230130162729.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "7b7abee4f57f0b35f46e51b84d926706f99afc23"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```