### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230130162800.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:08532c9f6e2b92e3d08165b6d8726e862fd5183044bda151fc760d30f43c28a2
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230130162800.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 6fd331c044c96a885bb8fdc1373822b08086758d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:08532c9f6e2b92e3d08165b6d8726e862fd5183044bda151fc760d30f43c28a2",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230130162800.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "6fd331c044c96a885bb8fdc1373822b08086758d"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:08532c9f6e2b92e3d08165b6d8726e862fd5183044bda151fc760d30f43c28a2",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230130162800.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "6fd331c044c96a885bb8fdc1373822b08086758d"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```