### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230201160005.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:c9c22b82a3d3b1f1958275db416c6e10e67cb4e7c2615112982a51228a9e6d6b
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230201160005.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 8ddccd8c21d1c06b22a910f1e44ef9c826fd6526
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c9c22b82a3d3b1f1958275db416c6e10e67cb4e7c2615112982a51228a9e6d6b",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230201160005.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "8ddccd8c21d1c06b22a910f1e44ef9c826fd6526"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c9c22b82a3d3b1f1958275db416c6e10e67cb4e7c2615112982a51228a9e6d6b",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230201160005.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "8ddccd8c21d1c06b22a910f1e44ef9c826fd6526"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```