### PR TITLE
chore(cd): update deck-armory version to 2023.02.02.17.06.37.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:af90d8463ba9a5275288b68ca657e8fe6d0ffaac0f24f032bbb976e1b78cd7dd
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2023.02.02.17.06.37.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: 75cc950a57ac93955a083e69303dbd9583544526
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "57a7190ca71a316ec8739dc25f6b5703a14fb3e5"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:af90d8463ba9a5275288b68ca657e8fe6d0ffaac0f24f032bbb976e1b78cd7dd",
        "repository": "armory/deck-armory",
        "tag": "2023.02.02.17.06.37.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "75cc950a57ac93955a083e69303dbd9583544526"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "57a7190ca71a316ec8739dc25f6b5703a14fb3e5"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:af90d8463ba9a5275288b68ca657e8fe6d0ffaac0f24f032bbb976e1b78cd7dd",
        "repository": "armory/deck-armory",
        "tag": "2023.02.02.17.06.37.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "75cc950a57ac93955a083e69303dbd9583544526"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```