### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230207184608.release-1.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:21838e7b13ecec9339cf0884750d3a78ece77644be27201edd35cb93ffbedcd5
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230207184608.release-1.29.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 6d9f5050840c48040edb6435c7a22640412092c7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:21838e7b13ecec9339cf0884750d3a78ece77644be27201edd35cb93ffbedcd5",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230207184608.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "6d9f5050840c48040edb6435c7a22640412092c7"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:21838e7b13ecec9339cf0884750d3a78ece77644be27201edd35cb93ffbedcd5",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230207184608.release-1.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "6d9f5050840c48040edb6435c7a22640412092c7"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```