### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230208060212.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:8078cb7c6c7a2af6fb2ef21f3d92064bac71367a63b7b6eac7491b5de4165b4d
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230208060212.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 66e030e449141627807c6f09e9edd1327d01d7ef
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8078cb7c6c7a2af6fb2ef21f3d92064bac71367a63b7b6eac7491b5de4165b4d",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230208060212.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "66e030e449141627807c6f09e9edd1327d01d7ef"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8078cb7c6c7a2af6fb2ef21f3d92064bac71367a63b7b6eac7491b5de4165b4d",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230208060212.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "66e030e449141627807c6f09e9edd1327d01d7ef"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```