### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230208084216.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:726d6c8e5513cefb114d8d0a30c927f8e9bb9161c64d3d903642ea7e4c495646
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230208084216.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 86c1864e13cf0cf40d0248d8a3a80b43ea2caa07
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:726d6c8e5513cefb114d8d0a30c927f8e9bb9161c64d3d903642ea7e4c495646",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230208084216.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "86c1864e13cf0cf40d0248d8a3a80b43ea2caa07"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:726d6c8e5513cefb114d8d0a30c927f8e9bb9161c64d3d903642ea7e4c495646",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230208084216.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "86c1864e13cf0cf40d0248d8a3a80b43ea2caa07"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```