### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230208194844.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:394ad2c468e9632937b570c5b3d38522fb56306857bf85957ee8c818396e71bd
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230208194844.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: f9eadd3cb694abd9e8070ef9ab67d6d416e3d459
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:394ad2c468e9632937b570c5b3d38522fb56306857bf85957ee8c818396e71bd",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230208194844.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "f9eadd3cb694abd9e8070ef9ab67d6d416e3d459"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:394ad2c468e9632937b570c5b3d38522fb56306857bf85957ee8c818396e71bd",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230208194844.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "f9eadd3cb694abd9e8070ef9ab67d6d416e3d459"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```