### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230208195333.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:714b1e78c2974d5268a1444923e6515793208a19b3c6730bb353be5df49893c1
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230208195333.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 4051785609a9beed27b4e0c37863e511b35038f0
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:714b1e78c2974d5268a1444923e6515793208a19b3c6730bb353be5df49893c1",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230208195333.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "4051785609a9beed27b4e0c37863e511b35038f0"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:714b1e78c2974d5268a1444923e6515793208a19b3c6730bb353be5df49893c1",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230208195333.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "4051785609a9beed27b4e0c37863e511b35038f0"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```