### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230208221931.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:13cdc9d9196d4e15c54112e8fa30e9b71d0b6b6ad68991f4ae0568599bab04ad
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230208221931.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 75e9519b4d9317a10ca3d5a911936d0a12002f3e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:13cdc9d9196d4e15c54112e8fa30e9b71d0b6b6ad68991f4ae0568599bab04ad",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230208221931.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "75e9519b4d9317a10ca3d5a911936d0a12002f3e"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:13cdc9d9196d4e15c54112e8fa30e9b71d0b6b6ad68991f4ae0568599bab04ad",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230208221931.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "75e9519b4d9317a10ca3d5a911936d0a12002f3e"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```