### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230208221942.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:bfc3aebcd0727196839bba7ed13d603af38ee109a896fa27795a7b965065884a
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230208221942.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: e356ec68a0f0419ccf5561fd2ebbe06625775f97
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:bfc3aebcd0727196839bba7ed13d603af38ee109a896fa27795a7b965065884a",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230208221942.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "e356ec68a0f0419ccf5561fd2ebbe06625775f97"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:bfc3aebcd0727196839bba7ed13d603af38ee109a896fa27795a7b965065884a",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230208221942.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "e356ec68a0f0419ccf5561fd2ebbe06625775f97"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```