### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230208232955.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:37afd7660df4c12fbf9ef2a5879d21d4da45a6532594964a1d39de532e7cf25a
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230208232955.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 1852d693d16a19f99905a76358f5847b980d34a6
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:37afd7660df4c12fbf9ef2a5879d21d4da45a6532594964a1d39de532e7cf25a",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230208232955.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "1852d693d16a19f99905a76358f5847b980d34a6"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:37afd7660df4c12fbf9ef2a5879d21d4da45a6532594964a1d39de532e7cf25a",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230208232955.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "1852d693d16a19f99905a76358f5847b980d34a6"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```