### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230209005551.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:775ff8c386fb5925e2f80edb9dbd25661f537f7b46146a6c5bed0ae849b3c694
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230209005551.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 09edbfdd6c236e73b2173fcce28d401c0b245cd2
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:775ff8c386fb5925e2f80edb9dbd25661f537f7b46146a6c5bed0ae849b3c694",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230209005551.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "09edbfdd6c236e73b2173fcce28d401c0b245cd2"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:775ff8c386fb5925e2f80edb9dbd25661f537f7b46146a6c5bed0ae849b3c694",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230209005551.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "09edbfdd6c236e73b2173fcce28d401c0b245cd2"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```