### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230209005656.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:79419bc715574c0a17aefaaceaced2fe9a025b929a285ea92e3570666a6fb797
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230209005656.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 5171d99a5e4cbc50eff8c6138d1088a5163b8904
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:79419bc715574c0a17aefaaceaced2fe9a025b929a285ea92e3570666a6fb797",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230209005656.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "5171d99a5e4cbc50eff8c6138d1088a5163b8904"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:79419bc715574c0a17aefaaceaced2fe9a025b929a285ea92e3570666a6fb797",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230209005656.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "5171d99a5e4cbc50eff8c6138d1088a5163b8904"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```