### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230209013858.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:5f1aecbe221ef5f3f74e95bc3a923bee50e17132b378e5ad5454fe96cf53e9ba
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230209013858.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: d954b4ff96c3fdd77665c6278387010bb6cc618f
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5f1aecbe221ef5f3f74e95bc3a923bee50e17132b378e5ad5454fe96cf53e9ba",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230209013858.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "d954b4ff96c3fdd77665c6278387010bb6cc618f"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5f1aecbe221ef5f3f74e95bc3a923bee50e17132b378e5ad5454fe96cf53e9ba",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230209013858.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "d954b4ff96c3fdd77665c6278387010bb6cc618f"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```