### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230209050213.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:27d93a5344b580d6afb5ce51c52221ed0e69a368d7c528f753f7c3c0c9dc61df
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230209050213.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 60312309a9eb7bf458b9455019a6c7827111dc35
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:27d93a5344b580d6afb5ce51c52221ed0e69a368d7c528f753f7c3c0c9dc61df",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230209050213.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "60312309a9eb7bf458b9455019a6c7827111dc35"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:27d93a5344b580d6afb5ce51c52221ed0e69a368d7c528f753f7c3c0c9dc61df",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230209050213.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "60312309a9eb7bf458b9455019a6c7827111dc35"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```