### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230209063426.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:fcd5a8adc55b7c01338c2b6940d44dd41e1c3dc58302da047de715a2fdd268b5
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230209063426.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: fa50e97551a3a956bd67f8513531a658c324ff9b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fcd5a8adc55b7c01338c2b6940d44dd41e1c3dc58302da047de715a2fdd268b5",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230209063426.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "fa50e97551a3a956bd67f8513531a658c324ff9b"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fcd5a8adc55b7c01338c2b6940d44dd41e1c3dc58302da047de715a2fdd268b5",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230209063426.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "fa50e97551a3a956bd67f8513531a658c324ff9b"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```