### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230209063331.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:2870830a9e0c5c5cba0ea2b75d255ccb294625ee677c8dec5fcd5a2a02db65f0
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230209063331.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: ff8a02284c1cb2ff9ae9a0adc4d447abce22897a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2870830a9e0c5c5cba0ea2b75d255ccb294625ee677c8dec5fcd5a2a02db65f0",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230209063331.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ff8a02284c1cb2ff9ae9a0adc4d447abce22897a"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2870830a9e0c5c5cba0ea2b75d255ccb294625ee677c8dec5fcd5a2a02db65f0",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230209063331.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ff8a02284c1cb2ff9ae9a0adc4d447abce22897a"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```