### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230209063532.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:04baa1596a584153721f84337cc2c3c7268961f5b3a783b1b75be6666e942f44
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230209063532.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 944f3f438f9e34b7bc3e9570f82ce84969682bc9
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:04baa1596a584153721f84337cc2c3c7268961f5b3a783b1b75be6666e942f44",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230209063532.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "944f3f438f9e34b7bc3e9570f82ce84969682bc9"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:04baa1596a584153721f84337cc2c3c7268961f5b3a783b1b75be6666e942f44",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230209063532.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "944f3f438f9e34b7bc3e9570f82ce84969682bc9"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```