### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230209071108.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:eb1bacdf4cb2db39a1c8f02a5b903a9760e1402322abeff53b16950a53f5e79e
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230209071108.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: aa8e9d95e5a678b80db8062d6a5ab4410e7f8da3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:eb1bacdf4cb2db39a1c8f02a5b903a9760e1402322abeff53b16950a53f5e79e",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230209071108.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "aa8e9d95e5a678b80db8062d6a5ab4410e7f8da3"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:eb1bacdf4cb2db39a1c8f02a5b903a9760e1402322abeff53b16950a53f5e79e",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230209071108.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "aa8e9d95e5a678b80db8062d6a5ab4410e7f8da3"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```