### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230214050828.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:f1385b94b3c6da996afc23ed63bf9ac2f0f174c78eea8e4ee6b51171dde68a78
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230214050828.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 27ed95187797d8553676d54fc75b240586902386
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f1385b94b3c6da996afc23ed63bf9ac2f0f174c78eea8e4ee6b51171dde68a78",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230214050828.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "27ed95187797d8553676d54fc75b240586902386"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f1385b94b3c6da996afc23ed63bf9ac2f0f174c78eea8e4ee6b51171dde68a78",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230214050828.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "27ed95187797d8553676d54fc75b240586902386"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```