### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230214095133.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:f72fd316f0bf7d52ba332e6475126434a16d578c112f0f6ba1ac25c58ef883d2
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230214095133.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 830fc336e4a29bff1dde6da874fb94a7d5a26328
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f72fd316f0bf7d52ba332e6475126434a16d578c112f0f6ba1ac25c58ef883d2",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230214095133.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "830fc336e4a29bff1dde6da874fb94a7d5a26328"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f72fd316f0bf7d52ba332e6475126434a16d578c112f0f6ba1ac25c58ef883d2",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230214095133.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "830fc336e4a29bff1dde6da874fb94a7d5a26328"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```