### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230215211208.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:477216b25081be3c0faae4ad1214e0dfb4bc38b221d5c9ba5527032e2fc9472d
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230215211208.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 19aca8488a3bc9a6df381721b1e791a9487be9f6
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:477216b25081be3c0faae4ad1214e0dfb4bc38b221d5c9ba5527032e2fc9472d",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230215211208.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "19aca8488a3bc9a6df381721b1e791a9487be9f6"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:477216b25081be3c0faae4ad1214e0dfb4bc38b221d5c9ba5527032e2fc9472d",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230215211208.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "19aca8488a3bc9a6df381721b1e791a9487be9f6"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```