### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230220195321.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:4cbe05d37bc29f1b15d663f31e4a0d977da01f462e80cd175b2f184bcbbdd278
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230220195321.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 32835c6b4940c0b5277099771ecd7a5abc9e39ee
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4cbe05d37bc29f1b15d663f31e4a0d977da01f462e80cd175b2f184bcbbdd278",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230220195321.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "32835c6b4940c0b5277099771ecd7a5abc9e39ee"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4cbe05d37bc29f1b15d663f31e4a0d977da01f462e80cd175b2f184bcbbdd278",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230220195321.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "32835c6b4940c0b5277099771ecd7a5abc9e39ee"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```