### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230220210803.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:8570361ff517ea9f6963763010e3905428086d717005621a8ae0fc06b94a66a9
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230220210803.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 03f1c535f08f806de05252b076322ca1985de323
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8570361ff517ea9f6963763010e3905428086d717005621a8ae0fc06b94a66a9",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230220210803.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "03f1c535f08f806de05252b076322ca1985de323"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8570361ff517ea9f6963763010e3905428086d717005621a8ae0fc06b94a66a9",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230220210803.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "03f1c535f08f806de05252b076322ca1985de323"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```