### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230220210915.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:a007b99d5efb420ad74afb9164073dd9322d039221d351f453ee8cc28593bd36
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230220210915.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 37a155e7ac12ee7b8e01757c4d93ca375fa9c176
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a007b99d5efb420ad74afb9164073dd9322d039221d351f453ee8cc28593bd36",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230220210915.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "37a155e7ac12ee7b8e01757c4d93ca375fa9c176"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a007b99d5efb420ad74afb9164073dd9322d039221d351f453ee8cc28593bd36",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230220210915.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "37a155e7ac12ee7b8e01757c4d93ca375fa9c176"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```