### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230220210858.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:19223b266b3fd27cb00e6af5d010a7f69b380e4373638ba86eb9093889d8435d
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230220210858.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: db9e72d3c1680fe59f7bc833bf53316025b7b1e6
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:19223b266b3fd27cb00e6af5d010a7f69b380e4373638ba86eb9093889d8435d",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230220210858.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "db9e72d3c1680fe59f7bc833bf53316025b7b1e6"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:19223b266b3fd27cb00e6af5d010a7f69b380e4373638ba86eb9093889d8435d",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230220210858.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "db9e72d3c1680fe59f7bc833bf53316025b7b1e6"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```