### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230220215130.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:8bbb446011e962f538f86c7131c0e2ed35424f5c727e3c483f49fef6e86cfe66
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230220215130.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: ca181589af5d77628bad7daff6f2ed6823c242ac
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8bbb446011e962f538f86c7131c0e2ed35424f5c727e3c483f49fef6e86cfe66",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230220215130.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "ca181589af5d77628bad7daff6f2ed6823c242ac"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8bbb446011e962f538f86c7131c0e2ed35424f5c727e3c483f49fef6e86cfe66",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230220215130.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "ca181589af5d77628bad7daff6f2ed6823c242ac"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```