### PR TITLE
chore(cd): update spinnaker-kayenta version to 2023.0.0-20230221171018.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-kayenta:
+    image:
+      imageId: sha256:7e596d946f0f7a72ef23413edcfe05bb18a194c8e1b29ed1abe2cbf0ed51fe06
+      repository: armory/spinnaker-kayenta
+      tag: 2023.0.0-20230221171018.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: kayenta
+        type: github
+      sha: 5613331ebcb4ea09df0cf1aa650ce596fd2340db
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7e596d946f0f7a72ef23413edcfe05bb18a194c8e1b29ed1abe2cbf0ed51fe06",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2023.0.0-20230221171018.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "5613331ebcb4ea09df0cf1aa650ce596fd2340db"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7e596d946f0f7a72ef23413edcfe05bb18a194c8e1b29ed1abe2cbf0ed51fe06",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2023.0.0-20230221171018.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "5613331ebcb4ea09df0cf1aa650ce596fd2340db"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```