### PR TITLE
chore(cd): update spinnaker-kayenta version to 2023.0.0-20230221185631.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-kayenta:
+    image:
+      imageId: sha256:b08c066eb46c943e0d40fe6a1f879b46a690300cef0b8aeab74e29709b0192c2
+      repository: armory/spinnaker-kayenta
+      tag: 2023.0.0-20230221185631.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: kayenta
+        type: github
+      sha: e5c77b5d43b23d1e4ca2ed10479394960916c5d7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b08c066eb46c943e0d40fe6a1f879b46a690300cef0b8aeab74e29709b0192c2",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2023.0.0-20230221185631.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "e5c77b5d43b23d1e4ca2ed10479394960916c5d7"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b08c066eb46c943e0d40fe6a1f879b46a690300cef0b8aeab74e29709b0192c2",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2023.0.0-20230221185631.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "e5c77b5d43b23d1e4ca2ed10479394960916c5d7"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```