### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230222201212.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:91f5eb965254c0f5b34401530245ba6739604327f0c7b332074e1756c8c7767c
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230222201212.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 07b1d87503e41800448d363a9ea41938f82c1d50
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:91f5eb965254c0f5b34401530245ba6739604327f0c7b332074e1756c8c7767c",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230222201212.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "07b1d87503e41800448d363a9ea41938f82c1d50"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:91f5eb965254c0f5b34401530245ba6739604327f0c7b332074e1756c8c7767c",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230222201212.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "07b1d87503e41800448d363a9ea41938f82c1d50"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```