### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230222230000.release-1.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:77fa5a3ec66a8c79dea4b71cc0cf6f9746e67ba62277a52e25d8601ede1557a2
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230222230000.release-1.28.x
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: b7a4239b30cacf31cbf121d803e5956091e8534f
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "release-1.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:77fa5a3ec66a8c79dea4b71cc0cf6f9746e67ba62277a52e25d8601ede1557a2",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230222230000.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b7a4239b30cacf31cbf121d803e5956091e8534f"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:77fa5a3ec66a8c79dea4b71cc0cf6f9746e67ba62277a52e25d8601ede1557a2",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230222230000.release-1.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b7a4239b30cacf31cbf121d803e5956091e8534f"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```