### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230302060752.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:82c35ae9b6765cbb5dc1dab64e506e0b4f33639b6d9ef029a01ada0e7792ddbe
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230302060752.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 88a7216f05c626109a749df922e1b3aff71c98d8
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:82c35ae9b6765cbb5dc1dab64e506e0b4f33639b6d9ef029a01ada0e7792ddbe",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230302060752.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "88a7216f05c626109a749df922e1b3aff71c98d8"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:82c35ae9b6765cbb5dc1dab64e506e0b4f33639b6d9ef029a01ada0e7792ddbe",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230302060752.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "88a7216f05c626109a749df922e1b3aff71c98d8"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```