### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230308180404.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:06a8b46d028ae1a7c48e0c42df1819d4b0431dc5b6563eb9c46d9f52b6b784c6
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230308180404.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 5b7fb1c3cbb6be5ce68ebfe524b91e80a40fa263
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:06a8b46d028ae1a7c48e0c42df1819d4b0431dc5b6563eb9c46d9f52b6b784c6",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230308180404.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "5b7fb1c3cbb6be5ce68ebfe524b91e80a40fa263"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:06a8b46d028ae1a7c48e0c42df1819d4b0431dc5b6563eb9c46d9f52b6b784c6",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230308180404.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "5b7fb1c3cbb6be5ce68ebfe524b91e80a40fa263"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```