### PR TITLE
chore(cd): update deck-armory version to 2023.03.10.12.35.33.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:dcadd6229e49c1a938c34183f674b60b63701acfaa4a500605d072b842b113ca
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2023.03.10.12.35.33.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: e09497a677c0700fc304cebcad904cd844ee3c5b
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "3611e9520b2294454a8b5dddc85cb3190722ffc7"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:dcadd6229e49c1a938c34183f674b60b63701acfaa4a500605d072b842b113ca",
        "repository": "armory/deck-armory",
        "tag": "2023.03.10.12.35.33.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "e09497a677c0700fc304cebcad904cd844ee3c5b"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "3611e9520b2294454a8b5dddc85cb3190722ffc7"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:dcadd6229e49c1a938c34183f674b60b63701acfaa4a500605d072b842b113ca",
        "repository": "armory/deck-armory",
        "tag": "2023.03.10.12.35.33.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "e09497a677c0700fc304cebcad904cd844ee3c5b"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```