### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230313214907.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:f47b6dfd984e61bbb79cf22d0a060e4d0b59d8026ff43583027a0be54a5cb73c
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230313214907.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 6462c386af716c3e4302df40cfdad2f4c157cc4b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f47b6dfd984e61bbb79cf22d0a060e4d0b59d8026ff43583027a0be54a5cb73c",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230313214907.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "6462c386af716c3e4302df40cfdad2f4c157cc4b"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f47b6dfd984e61bbb79cf22d0a060e4d0b59d8026ff43583027a0be54a5cb73c",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230313214907.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "6462c386af716c3e4302df40cfdad2f4c157cc4b"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```