### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230313215126.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:fbc2f534120e7a66c9a570f542fcb96de76610ffd2f02644dec454332025a805
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230313215126.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 4c31f1b301476c6879d440d42fdb259745ed971a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fbc2f534120e7a66c9a570f542fcb96de76610ffd2f02644dec454332025a805",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230313215126.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "4c31f1b301476c6879d440d42fdb259745ed971a"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fbc2f534120e7a66c9a570f542fcb96de76610ffd2f02644dec454332025a805",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230313215126.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "4c31f1b301476c6879d440d42fdb259745ed971a"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```