### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230313215250.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:51e36505de23782729787da12dc7fbc959da8e30ea0b1a628abd69076cf255ef
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230313215250.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: ab36bf2e5c07b9d8c453a27f1028d8d234ff952f
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:51e36505de23782729787da12dc7fbc959da8e30ea0b1a628abd69076cf255ef",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230313215250.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ab36bf2e5c07b9d8c453a27f1028d8d234ff952f"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:51e36505de23782729787da12dc7fbc959da8e30ea0b1a628abd69076cf255ef",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230313215250.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ab36bf2e5c07b9d8c453a27f1028d8d234ff952f"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```