### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230313215510.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:30aedc324b075f776fc31778e8b7edbfbc5c6bf4ec64f18f453054e0a786d691
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230313215510.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 6c93cc6239c88086e30ed70f4185adc8d1b928d3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:30aedc324b075f776fc31778e8b7edbfbc5c6bf4ec64f18f453054e0a786d691",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230313215510.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "6c93cc6239c88086e30ed70f4185adc8d1b928d3"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:30aedc324b075f776fc31778e8b7edbfbc5c6bf4ec64f18f453054e0a786d691",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230313215510.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "6c93cc6239c88086e30ed70f4185adc8d1b928d3"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```