### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230313222844.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:937ee3b40c531bf863a27c1d5f82154b411409f1d5f9d820486f7bc556e35173
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230313222844.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 909b6ff11dad82268a0b4401f70cabc9b4a3f3ed
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:937ee3b40c531bf863a27c1d5f82154b411409f1d5f9d820486f7bc556e35173",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230313222844.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "909b6ff11dad82268a0b4401f70cabc9b4a3f3ed"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:937ee3b40c531bf863a27c1d5f82154b411409f1d5f9d820486f7bc556e35173",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230313222844.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "909b6ff11dad82268a0b4401f70cabc9b4a3f3ed"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```