### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230316153545.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:733779c7de2d8a6111f3601be0d2d42fe1b0142b9d2c4d1ba9e7597a0b10e9ca
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230316153545.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 092eff250bc4f10ae6681d6174bf5a56d889c5bf
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:733779c7de2d8a6111f3601be0d2d42fe1b0142b9d2c4d1ba9e7597a0b10e9ca",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230316153545.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "092eff250bc4f10ae6681d6174bf5a56d889c5bf"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:733779c7de2d8a6111f3601be0d2d42fe1b0142b9d2c4d1ba9e7597a0b10e9ca",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230316153545.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "092eff250bc4f10ae6681d6174bf5a56d889c5bf"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```