### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230317231159.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:87aa4819ec1aefdf7f0bd14bf38d8516f89ec2d67864df953c463a9fbf3082aa
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230317231159.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: e53b1fdc85486e5a02738bf27c7c5d222e6afaea
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:87aa4819ec1aefdf7f0bd14bf38d8516f89ec2d67864df953c463a9fbf3082aa",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230317231159.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "e53b1fdc85486e5a02738bf27c7c5d222e6afaea"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:87aa4819ec1aefdf7f0bd14bf38d8516f89ec2d67864df953c463a9fbf3082aa",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230317231159.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "e53b1fdc85486e5a02738bf27c7c5d222e6afaea"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```