### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230321003133.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:a738b62400d9dea73081c98b4bc0fd0194dabeca4a06cbf0ff851ddd7072b309
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230321003133.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 8d6a4e7d2088c6067169337acb9c1df94c378249
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a738b62400d9dea73081c98b4bc0fd0194dabeca4a06cbf0ff851ddd7072b309",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230321003133.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "8d6a4e7d2088c6067169337acb9c1df94c378249"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a738b62400d9dea73081c98b4bc0fd0194dabeca4a06cbf0ff851ddd7072b309",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230321003133.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "8d6a4e7d2088c6067169337acb9c1df94c378249"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```