### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230323210103.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:e11e2ef3b9ca2c2badecd5f8739a2ef5f39902738bea10d9af7bf0fe46e1a9c8
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230323210103.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 42b96835da0d5567cbe4d549c62a422ded7baf8d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e11e2ef3b9ca2c2badecd5f8739a2ef5f39902738bea10d9af7bf0fe46e1a9c8",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230323210103.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "42b96835da0d5567cbe4d549c62a422ded7baf8d"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e11e2ef3b9ca2c2badecd5f8739a2ef5f39902738bea10d9af7bf0fe46e1a9c8",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230323210103.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "42b96835da0d5567cbe4d549c62a422ded7baf8d"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```