### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230324230856.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:ef580fec40069a6fe7ded8d4110404a3bcc8a4bc47bd179ed4f53bd63818c229
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230324230856.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: f60c8604b0b6ccd5020178bb2c7f3996c22b01cb
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ef580fec40069a6fe7ded8d4110404a3bcc8a4bc47bd179ed4f53bd63818c229",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230324230856.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "f60c8604b0b6ccd5020178bb2c7f3996c22b01cb"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ef580fec40069a6fe7ded8d4110404a3bcc8a4bc47bd179ed4f53bd63818c229",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230324230856.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "f60c8604b0b6ccd5020178bb2c7f3996c22b01cb"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```