### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230324234826.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:f98a4b47528a1409a95aed4238a9549b5d72f114e6be18c5fc17dd190df54bf2
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230324234826.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 2b519e6d2842cdfeb996e2fcc02cec047835f5aa
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f98a4b47528a1409a95aed4238a9549b5d72f114e6be18c5fc17dd190df54bf2",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230324234826.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "2b519e6d2842cdfeb996e2fcc02cec047835f5aa"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f98a4b47528a1409a95aed4238a9549b5d72f114e6be18c5fc17dd190df54bf2",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230324234826.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "2b519e6d2842cdfeb996e2fcc02cec047835f5aa"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```