### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230329193252.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:3eedce641af66e6ce8ec484bc4580ff7f19e4a0ee0405fb5f67ce42de029b12e
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230329193252.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 27a9b60d9cacd713d1fcbb80aead3414ed9d49fc
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3eedce641af66e6ce8ec484bc4580ff7f19e4a0ee0405fb5f67ce42de029b12e",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230329193252.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "27a9b60d9cacd713d1fcbb80aead3414ed9d49fc"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3eedce641af66e6ce8ec484bc4580ff7f19e4a0ee0405fb5f67ce42de029b12e",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230329193252.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "27a9b60d9cacd713d1fcbb80aead3414ed9d49fc"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```