### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230329193529.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:fef24a9204feef327ba9392b6053e1e1bfe9e4c989875ab4a2e90ad01d4fcbe0
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230329193529.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 45b65d5dede70c246559503c72ac7488c548c4cf
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fef24a9204feef327ba9392b6053e1e1bfe9e4c989875ab4a2e90ad01d4fcbe0",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230329193529.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "45b65d5dede70c246559503c72ac7488c548c4cf"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fef24a9204feef327ba9392b6053e1e1bfe9e4c989875ab4a2e90ad01d4fcbe0",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230329193529.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "45b65d5dede70c246559503c72ac7488c548c4cf"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```