### PR TITLE
chore(cd): update spinnaker-kayenta version to 2023.0.0-20230329193341.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-kayenta:
+    image:
+      imageId: sha256:80798d0b23bf46bf937372c835285a08b7d53b743546082ee1a1d7765b67c801
+      repository: armory/spinnaker-kayenta
+      tag: 2023.0.0-20230329193341.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: kayenta
+        type: github
+      sha: d7e30f882083989138e25e96bdb68fe01516b884
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:80798d0b23bf46bf937372c835285a08b7d53b743546082ee1a1d7765b67c801",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2023.0.0-20230329193341.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "d7e30f882083989138e25e96bdb68fe01516b884"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:80798d0b23bf46bf937372c835285a08b7d53b743546082ee1a1d7765b67c801",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2023.0.0-20230329193341.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "d7e30f882083989138e25e96bdb68fe01516b884"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```