### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230330143631.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:b5e8e92c2f1b4fc99e9742df16301663bfec90d08bf96bb8d29efb82daa27b54
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230330143631.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: db3a9b93d38c3a201b8249ee74f65862b5c44552
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b5e8e92c2f1b4fc99e9742df16301663bfec90d08bf96bb8d29efb82daa27b54",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230330143631.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "db3a9b93d38c3a201b8249ee74f65862b5c44552"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b5e8e92c2f1b4fc99e9742df16301663bfec90d08bf96bb8d29efb82daa27b54",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230330143631.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "db3a9b93d38c3a201b8249ee74f65862b5c44552"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```