### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230330161010.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:e4ae1f651524d4c63460cb9cf173f9f2dfe6e1f65f747e9879dce4cbe952948f
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230330161010.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 40b6687cb126c94d56bf677b85ed545e5838bbd9
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e4ae1f651524d4c63460cb9cf173f9f2dfe6e1f65f747e9879dce4cbe952948f",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230330161010.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "40b6687cb126c94d56bf677b85ed545e5838bbd9"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e4ae1f651524d4c63460cb9cf173f9f2dfe6e1f65f747e9879dce4cbe952948f",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230330161010.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "40b6687cb126c94d56bf677b85ed545e5838bbd9"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```