### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230331173747.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:90c85e95c9003f088fc052ffe0c5e85322b4223a8e7fedfe016f5960895e8785
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230331173747.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 9e491704774cb279c4baa0960554951f2f645c84
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:90c85e95c9003f088fc052ffe0c5e85322b4223a8e7fedfe016f5960895e8785",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331173747.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "9e491704774cb279c4baa0960554951f2f645c84"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:90c85e95c9003f088fc052ffe0c5e85322b4223a8e7fedfe016f5960895e8785",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331173747.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "9e491704774cb279c4baa0960554951f2f645c84"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```