### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230331195629.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:ddbc75d1a28d865897a9b859734395abe617c5e2a2bb54a1b8e37a3427def0c2
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230331195629.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 8dfff9f294b464c850f22f3890fc22e38c38f389
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ddbc75d1a28d865897a9b859734395abe617c5e2a2bb54a1b8e37a3427def0c2",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230331195629.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "8dfff9f294b464c850f22f3890fc22e38c38f389"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ddbc75d1a28d865897a9b859734395abe617c5e2a2bb54a1b8e37a3427def0c2",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230331195629.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "8dfff9f294b464c850f22f3890fc22e38c38f389"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```