### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230331214130.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:9848e16cee78441399317492f4958be6f53ec872d2f1be9e643d49af2355fd2f
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230331214130.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 6ff56abacddc5021a977160b2f8dd69a35229ffb
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:9848e16cee78441399317492f4958be6f53ec872d2f1be9e643d49af2355fd2f",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331214130.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "6ff56abacddc5021a977160b2f8dd69a35229ffb"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:9848e16cee78441399317492f4958be6f53ec872d2f1be9e643d49af2355fd2f",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331214130.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "6ff56abacddc5021a977160b2f8dd69a35229ffb"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```