### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230331214727.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:0cfb75e9e1b0dfb973256442fa162ca6d6269f8ef157654fff18545af7aaf33d
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230331214727.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 0f941f82cfe54e6b2a97df4b0d71a9257d1e71e9
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:0cfb75e9e1b0dfb973256442fa162ca6d6269f8ef157654fff18545af7aaf33d",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230331214727.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "0f941f82cfe54e6b2a97df4b0d71a9257d1e71e9"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:0cfb75e9e1b0dfb973256442fa162ca6d6269f8ef157654fff18545af7aaf33d",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230331214727.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "0f941f82cfe54e6b2a97df4b0d71a9257d1e71e9"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```