### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230331214917.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:2dce0ff961f3a6dce375afbd64945cdbca7234d9c8d56c23a48b87b29a5b46f0
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230331214917.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: c5ea73b345357328d0be59527842f8dfb2517d57
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2dce0ff961f3a6dce375afbd64945cdbca7234d9c8d56c23a48b87b29a5b46f0",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331214917.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "c5ea73b345357328d0be59527842f8dfb2517d57"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2dce0ff961f3a6dce375afbd64945cdbca7234d9c8d56c23a48b87b29a5b46f0",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331214917.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "c5ea73b345357328d0be59527842f8dfb2517d57"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```