### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230331214938.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:af5f710db18d1515b781dc05a82cf8b31ba00de0f9b8a761c1fd94bd3eca6f2d
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230331214938.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: e16fafd84fc554e2821f0c9f87bd5e0ddc2c4222
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:af5f710db18d1515b781dc05a82cf8b31ba00de0f9b8a761c1fd94bd3eca6f2d",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331214938.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "e16fafd84fc554e2821f0c9f87bd5e0ddc2c4222"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:af5f710db18d1515b781dc05a82cf8b31ba00de0f9b8a761c1fd94bd3eca6f2d",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331214938.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "e16fafd84fc554e2821f0c9f87bd5e0ddc2c4222"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```