### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230331220113.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:3cefd2099c65f786be5a9d2d4d016ceba90662275878d13ef37c05bfc8fbbc5b
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230331220113.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 3904db83c9058a3485a6bd813e6e5fb8a33e6a9e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3cefd2099c65f786be5a9d2d4d016ceba90662275878d13ef37c05bfc8fbbc5b",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230331220113.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "3904db83c9058a3485a6bd813e6e5fb8a33e6a9e"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3cefd2099c65f786be5a9d2d4d016ceba90662275878d13ef37c05bfc8fbbc5b",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230331220113.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "3904db83c9058a3485a6bd813e6e5fb8a33e6a9e"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```