### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230331220241.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:9026ff17704bf9d1a6a7fdfd20e65781d0c0e73532987cd234af60428929cc4d
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230331220241.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 02c81d23b2d3753e3f627d79673c4a15b94023f7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:9026ff17704bf9d1a6a7fdfd20e65781d0c0e73532987cd234af60428929cc4d",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331220241.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "02c81d23b2d3753e3f627d79673c4a15b94023f7"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:9026ff17704bf9d1a6a7fdfd20e65781d0c0e73532987cd234af60428929cc4d",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331220241.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "02c81d23b2d3753e3f627d79673c4a15b94023f7"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```