### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230331220907.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:d3ac10247b3251e2b25f7ef3db25ae98404f64a8adaaa88e9f6b33ffcad5b307
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230331220907.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 0eae97bc2281f0f4d76c71e149f5f4cd27611fe1
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d3ac10247b3251e2b25f7ef3db25ae98404f64a8adaaa88e9f6b33ffcad5b307",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230331220907.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "0eae97bc2281f0f4d76c71e149f5f4cd27611fe1"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d3ac10247b3251e2b25f7ef3db25ae98404f64a8adaaa88e9f6b33ffcad5b307",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230331220907.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "0eae97bc2281f0f4d76c71e149f5f4cd27611fe1"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```