### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230331221952.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:7992eb168571fb7100c3e83a2892e0515ff007bd580b83c47b46232443e90be6
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230331221952.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 97777fa8e9f70ae58c9638afabbcbb0eafaf26cd
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7992eb168571fb7100c3e83a2892e0515ff007bd580b83c47b46232443e90be6",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331221952.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "97777fa8e9f70ae58c9638afabbcbb0eafaf26cd"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7992eb168571fb7100c3e83a2892e0515ff007bd580b83c47b46232443e90be6",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331221952.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "97777fa8e9f70ae58c9638afabbcbb0eafaf26cd"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```