### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230331222024.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:49a6af83c64274f329b479862279c9d2710600c64c0489c26c85b5918edb89f9
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230331222024.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 3514c768c2d743dd767de7fbd981b791610ceee9
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:49a6af83c64274f329b479862279c9d2710600c64c0489c26c85b5918edb89f9",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230331222024.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "3514c768c2d743dd767de7fbd981b791610ceee9"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:49a6af83c64274f329b479862279c9d2710600c64c0489c26c85b5918edb89f9",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230331222024.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "3514c768c2d743dd767de7fbd981b791610ceee9"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```