### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230331221814.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:0607c3a8a745b2be050f82868e8d444863689fda87e486c7e686e58fa2915313
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230331221814.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 063ec6c74bd444781584f1f5598347728b8c9991
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:0607c3a8a745b2be050f82868e8d444863689fda87e486c7e686e58fa2915313",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331221814.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "063ec6c74bd444781584f1f5598347728b8c9991"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:0607c3a8a745b2be050f82868e8d444863689fda87e486c7e686e58fa2915313",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331221814.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "063ec6c74bd444781584f1f5598347728b8c9991"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```