### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230331222757.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:9471ae93009583ad3f54110d7c1eb31c3cafc4739f05e599343eb82ca5523287
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230331222757.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: f64ebda731cd1103041bb7cf60cd53274556f147
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:9471ae93009583ad3f54110d7c1eb31c3cafc4739f05e599343eb82ca5523287",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230331222757.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "f64ebda731cd1103041bb7cf60cd53274556f147"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:9471ae93009583ad3f54110d7c1eb31c3cafc4739f05e599343eb82ca5523287",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230331222757.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "f64ebda731cd1103041bb7cf60cd53274556f147"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```