### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230331222413.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:cc374ff549f142e2b3f888f7ef8ee90e21a346307de66921ea1ee09bf1010b87
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230331222413.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 6efa6ef5cc8de8e6cd45d20c655c95ed8dcfe6b4
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cc374ff549f142e2b3f888f7ef8ee90e21a346307de66921ea1ee09bf1010b87",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230331222413.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "6efa6ef5cc8de8e6cd45d20c655c95ed8dcfe6b4"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cc374ff549f142e2b3f888f7ef8ee90e21a346307de66921ea1ee09bf1010b87",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230331222413.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "6efa6ef5cc8de8e6cd45d20c655c95ed8dcfe6b4"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```