### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230331223016.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:21eaed22510ecf6825963dc066c0c47819927fb5426c3543a8109f76194c21a4
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230331223016.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: dcb5aea9a55f90fd734a2fabd0e5c3e3f734c0cb
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:21eaed22510ecf6825963dc066c0c47819927fb5426c3543a8109f76194c21a4",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331223016.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "dcb5aea9a55f90fd734a2fabd0e5c3e3f734c0cb"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:21eaed22510ecf6825963dc066c0c47819927fb5426c3543a8109f76194c21a4",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331223016.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "dcb5aea9a55f90fd734a2fabd0e5c3e3f734c0cb"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```