### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230331222635.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:d28c2399e57160bf01da22b891ab49a71276fdf8c247a413e5519d9d68e3e805
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230331222635.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 0ddf0ebc66add810d468ddeff3408865b3def73c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d28c2399e57160bf01da22b891ab49a71276fdf8c247a413e5519d9d68e3e805",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331222635.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "0ddf0ebc66add810d468ddeff3408865b3def73c"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d28c2399e57160bf01da22b891ab49a71276fdf8c247a413e5519d9d68e3e805",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331222635.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "0ddf0ebc66add810d468ddeff3408865b3def73c"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```