### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230331223304.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:e2d6f59e2fff3d15c28da978c7e0e9afc7f8047a27b182fdc12d0f7d76792090
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230331223304.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 90a87117758bde54788e1d3a131626ac94fc14dc
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e2d6f59e2fff3d15c28da978c7e0e9afc7f8047a27b182fdc12d0f7d76792090",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230331223304.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "90a87117758bde54788e1d3a131626ac94fc14dc"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e2d6f59e2fff3d15c28da978c7e0e9afc7f8047a27b182fdc12d0f7d76792090",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230331223304.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "90a87117758bde54788e1d3a131626ac94fc14dc"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```