### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230331223712.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:e167f08ac821f91bf455f22ef444ab1c7195a0cf47d01486bbdb3f1c5998e056
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230331223712.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 5c0e799c163f05bf808de55a2458ffbc1eb8c936
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e167f08ac821f91bf455f22ef444ab1c7195a0cf47d01486bbdb3f1c5998e056",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331223712.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "5c0e799c163f05bf808de55a2458ffbc1eb8c936"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e167f08ac821f91bf455f22ef444ab1c7195a0cf47d01486bbdb3f1c5998e056",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331223712.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "5c0e799c163f05bf808de55a2458ffbc1eb8c936"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```