### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230331231639.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:4b73ca93f972fb0eaaf282b09aba2b52e4d400aabfdb0d2742bbc395da9961dd
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230331231639.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: f102c64efbcd5df17b925dc4e1cb571fc389de55
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4b73ca93f972fb0eaaf282b09aba2b52e4d400aabfdb0d2742bbc395da9961dd",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331231639.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "f102c64efbcd5df17b925dc4e1cb571fc389de55"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4b73ca93f972fb0eaaf282b09aba2b52e4d400aabfdb0d2742bbc395da9961dd",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230331231639.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "f102c64efbcd5df17b925dc4e1cb571fc389de55"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```