### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230331234842.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:f75d0c835228c84179a21844ce9a483edfcb075f74cd5ca2166b8c3ced45e953
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230331234842.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: e6753c09afe0f36e4dd36d3fe783edfcaaf63b94
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f75d0c835228c84179a21844ce9a483edfcb075f74cd5ca2166b8c3ced45e953",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331234842.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "e6753c09afe0f36e4dd36d3fe783edfcaaf63b94"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f75d0c835228c84179a21844ce9a483edfcb075f74cd5ca2166b8c3ced45e953",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230331234842.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "e6753c09afe0f36e4dd36d3fe783edfcaaf63b94"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```