### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230401001301.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:3cd6f0db6e96765a008834984b6fdfc239d298a545db404ac56332020e086e20
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230401001301.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: e968a929b5f206514b6d6bb1514b024c50a109ab
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3cd6f0db6e96765a008834984b6fdfc239d298a545db404ac56332020e086e20",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230401001301.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "e968a929b5f206514b6d6bb1514b024c50a109ab"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3cd6f0db6e96765a008834984b6fdfc239d298a545db404ac56332020e086e20",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230401001301.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "e968a929b5f206514b6d6bb1514b024c50a109ab"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```