### PR TITLE
chore(cd): update deck-armory version to 2023.04.01.00.34.14.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:66138b6503dae7f5bb5119c9559b5adb21320cabfaf4c03fda92c54e43a8e2d5
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2023.04.01.00.34.14.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: 7144cc3811bd7661c90298756f4fc938edc73ae6
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "50386cde312c3e50c2003a69508a50707117e0a1"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:66138b6503dae7f5bb5119c9559b5adb21320cabfaf4c03fda92c54e43a8e2d5",
        "repository": "armory/deck-armory",
        "tag": "2023.04.01.00.34.14.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "7144cc3811bd7661c90298756f4fc938edc73ae6"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "50386cde312c3e50c2003a69508a50707117e0a1"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:66138b6503dae7f5bb5119c9559b5adb21320cabfaf4c03fda92c54e43a8e2d5",
        "repository": "armory/deck-armory",
        "tag": "2023.04.01.00.34.14.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "7144cc3811bd7661c90298756f4fc938edc73ae6"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```