### PR TITLE
chore(cd): update deck-armory version to 2023.04.01.02.11.21.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:a02c264b0143801e0255e041483dbcae78699b8e527abd71088d6027d0b15009
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2023.04.01.02.11.21.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: c85a4a6d8af630df9ab4c75e1498578041471b1f
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "deac11183dfd40f68f3c68133706580e47021b14"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:a02c264b0143801e0255e041483dbcae78699b8e527abd71088d6027d0b15009",
        "repository": "armory/deck-armory",
        "tag": "2023.04.01.02.11.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "c85a4a6d8af630df9ab4c75e1498578041471b1f"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "deac11183dfd40f68f3c68133706580e47021b14"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:a02c264b0143801e0255e041483dbcae78699b8e527abd71088d6027d0b15009",
        "repository": "armory/deck-armory",
        "tag": "2023.04.01.02.11.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "c85a4a6d8af630df9ab4c75e1498578041471b1f"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```