### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230401052614.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:ef1e9fa895ba71547dd2efe0b7f9d8f90d6d8ec0ea112f705a7dd942ef68a272
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230401052614.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 2f25d1d520e82578f2b9a65cfbdf0ab44461f7c8
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ef1e9fa895ba71547dd2efe0b7f9d8f90d6d8ec0ea112f705a7dd942ef68a272",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230401052614.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "2f25d1d520e82578f2b9a65cfbdf0ab44461f7c8"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ef1e9fa895ba71547dd2efe0b7f9d8f90d6d8ec0ea112f705a7dd942ef68a272",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230401052614.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "2f25d1d520e82578f2b9a65cfbdf0ab44461f7c8"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```