### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230401064640.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:7434b19f7a8d1f7f723f03b4cdc1978bb2c6c34d746f479fe1e8ea4c6662c5bd
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230401064640.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: b69a12fb286a4a9bb3ebbb23417f2fd66c5b3aa3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7434b19f7a8d1f7f723f03b4cdc1978bb2c6c34d746f479fe1e8ea4c6662c5bd",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230401064640.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b69a12fb286a4a9bb3ebbb23417f2fd66c5b3aa3"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7434b19f7a8d1f7f723f03b4cdc1978bb2c6c34d746f479fe1e8ea4c6662c5bd",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230401064640.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b69a12fb286a4a9bb3ebbb23417f2fd66c5b3aa3"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```