### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230401163935.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:d20b1b42b7a79cd3616617c3ac4ad174bc504bed2ca0743651a7a7a2fd179570
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230401163935.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 29111887e6e49ac428f35d79917e910118ed9748
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d20b1b42b7a79cd3616617c3ac4ad174bc504bed2ca0743651a7a7a2fd179570",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230401163935.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "29111887e6e49ac428f35d79917e910118ed9748"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d20b1b42b7a79cd3616617c3ac4ad174bc504bed2ca0743651a7a7a2fd179570",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230401163935.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "29111887e6e49ac428f35d79917e910118ed9748"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```