### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230402042528.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:5fc4c2ad1c8a3b475f91dab5c2c059a6b127dc066671dd77f1697a77b1f5ac94
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230402042528.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 616d4c7ae2f39f0ac2c6970581b65ac5b69d9a55
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5fc4c2ad1c8a3b475f91dab5c2c059a6b127dc066671dd77f1697a77b1f5ac94",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230402042528.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "616d4c7ae2f39f0ac2c6970581b65ac5b69d9a55"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5fc4c2ad1c8a3b475f91dab5c2c059a6b127dc066671dd77f1697a77b1f5ac94",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230402042528.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "616d4c7ae2f39f0ac2c6970581b65ac5b69d9a55"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```