### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230402042511.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:a1f1e45ce44437d44b97c2cdb66cc28d378e3eb4028c27b30e7f01d03ffecbf3
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230402042511.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 0a32290a1ad3c1fdf505982cd84ca8851f171963
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a1f1e45ce44437d44b97c2cdb66cc28d378e3eb4028c27b30e7f01d03ffecbf3",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230402042511.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "0a32290a1ad3c1fdf505982cd84ca8851f171963"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a1f1e45ce44437d44b97c2cdb66cc28d378e3eb4028c27b30e7f01d03ffecbf3",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230402042511.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "0a32290a1ad3c1fdf505982cd84ca8851f171963"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```