### PR TITLE
chore(cd): update deck-armory version to 2023.04.02.06.05.21.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:d10dc0fec385f6c915e4f12ef631960191b7369689fc74f403c317bc50fbfc79
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2023.04.02.06.05.21.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: 859cfc55aa38d861171734d1e285f07864c1c2c0
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "9b114d50cb976653b365d9cfa23e0365329418f5"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:d10dc0fec385f6c915e4f12ef631960191b7369689fc74f403c317bc50fbfc79",
        "repository": "armory/deck-armory",
        "tag": "2023.04.02.06.05.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "859cfc55aa38d861171734d1e285f07864c1c2c0"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "9b114d50cb976653b365d9cfa23e0365329418f5"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:d10dc0fec385f6c915e4f12ef631960191b7369689fc74f403c317bc50fbfc79",
        "repository": "armory/deck-armory",
        "tag": "2023.04.02.06.05.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "859cfc55aa38d861171734d1e285f07864c1c2c0"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```