### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230403150726.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:c9b88556ccb387ccf189466c3913dee4e2cc48356ae66c5a44b2da4f624af2fb
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230403150726.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 2e4af99b88f89d2855af5446d1207d793137957a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c9b88556ccb387ccf189466c3913dee4e2cc48356ae66c5a44b2da4f624af2fb",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230403150726.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "2e4af99b88f89d2855af5446d1207d793137957a"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c9b88556ccb387ccf189466c3913dee4e2cc48356ae66c5a44b2da4f624af2fb",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230403150726.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "2e4af99b88f89d2855af5446d1207d793137957a"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```