### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230403155426.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:429dc0c01fa2fd9eebd1b0953d2fe0e638f3cb9fd700de0599d7591485b02894
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230403155426.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: b2c141ca67311e4d9093bea43ce4cca24713a7e1
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:429dc0c01fa2fd9eebd1b0953d2fe0e638f3cb9fd700de0599d7591485b02894",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230403155426.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b2c141ca67311e4d9093bea43ce4cca24713a7e1"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:429dc0c01fa2fd9eebd1b0953d2fe0e638f3cb9fd700de0599d7591485b02894",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230403155426.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "b2c141ca67311e4d9093bea43ce4cca24713a7e1"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```