### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230404162722.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:f8a09e92e75d75e6cfeba6a59f3bacc7e11c2d5156089875b7400cca2359dbc5
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230404162722.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 4ae6ea1283d9c587e05a179efe7e3b58aae53fc8
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f8a09e92e75d75e6cfeba6a59f3bacc7e11c2d5156089875b7400cca2359dbc5",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230404162722.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "4ae6ea1283d9c587e05a179efe7e3b58aae53fc8"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f8a09e92e75d75e6cfeba6a59f3bacc7e11c2d5156089875b7400cca2359dbc5",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230404162722.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "4ae6ea1283d9c587e05a179efe7e3b58aae53fc8"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```