### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230405110510.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:7d6587c6d1aa5a684cf793d142b07ec6ebfa4476248df8e869c83d9e99382e88
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230405110510.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 9d69060b92b90a103cf178de1ba5a90ba8e873d7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7d6587c6d1aa5a684cf793d142b07ec6ebfa4476248df8e869c83d9e99382e88",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230405110510.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "9d69060b92b90a103cf178de1ba5a90ba8e873d7"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7d6587c6d1aa5a684cf793d142b07ec6ebfa4476248df8e869c83d9e99382e88",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230405110510.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "9d69060b92b90a103cf178de1ba5a90ba8e873d7"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```