### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230405110345.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:18acd2b4df5901b996e2da219fa61022468814723206f70fcce27db732391a6a
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230405110345.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 24579af133c124e75c8bdb68bbe22bcd7d25f003
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:18acd2b4df5901b996e2da219fa61022468814723206f70fcce27db732391a6a",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230405110345.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "24579af133c124e75c8bdb68bbe22bcd7d25f003"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:18acd2b4df5901b996e2da219fa61022468814723206f70fcce27db732391a6a",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230405110345.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "24579af133c124e75c8bdb68bbe22bcd7d25f003"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```