### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230405110536.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:a06a37c9a2f74013cd0376a8d7fd432f407f130456694cb32f72758d0ec95831
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230405110536.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 722f49b3381cac5aa935e90e5ffd92ba00e8d520
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a06a37c9a2f74013cd0376a8d7fd432f407f130456694cb32f72758d0ec95831",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230405110536.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "722f49b3381cac5aa935e90e5ffd92ba00e8d520"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a06a37c9a2f74013cd0376a8d7fd432f407f130456694cb32f72758d0ec95831",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230405110536.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "722f49b3381cac5aa935e90e5ffd92ba00e8d520"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```