### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230405114353.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:4b1f07961e76dfaf461552033aaeaab91b730da19eb1825a1d0fbc784bab1908
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230405114353.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 42c0239e76040fc5208c10185eab67acf2be880e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4b1f07961e76dfaf461552033aaeaab91b730da19eb1825a1d0fbc784bab1908",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230405114353.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "42c0239e76040fc5208c10185eab67acf2be880e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4b1f07961e76dfaf461552033aaeaab91b730da19eb1825a1d0fbc784bab1908",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230405114353.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "42c0239e76040fc5208c10185eab67acf2be880e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```