### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230405213610.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:c19fc67f6970971a5169c62c424d1e6435936075060cf45d2296377934204aef
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230405213610.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 70f6177fb83d1be64463de4ac2745716c42a706e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c19fc67f6970971a5169c62c424d1e6435936075060cf45d2296377934204aef",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230405213610.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "70f6177fb83d1be64463de4ac2745716c42a706e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c19fc67f6970971a5169c62c424d1e6435936075060cf45d2296377934204aef",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230405213610.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "70f6177fb83d1be64463de4ac2745716c42a706e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```