### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230417185847.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:16d3830fba5c35a5b5d89d8bf11a741860297a820d6edb44ea5bb05240bc1718
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230417185847.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 5522d5c0b2037a6bd47b6ade5c6a40e71fd335e9
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:16d3830fba5c35a5b5d89d8bf11a741860297a820d6edb44ea5bb05240bc1718",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230417185847.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "5522d5c0b2037a6bd47b6ade5c6a40e71fd335e9"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:16d3830fba5c35a5b5d89d8bf11a741860297a820d6edb44ea5bb05240bc1718",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230417185847.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "5522d5c0b2037a6bd47b6ade5c6a40e71fd335e9"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```