### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230417185827.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:36b84df44dacae992395ac9c5be52ca3320892ed4f272d27eb4332dfdb13d3ee
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230417185827.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: a4eec5ae61d39448309a842367786b0470a71ca7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:36b84df44dacae992395ac9c5be52ca3320892ed4f272d27eb4332dfdb13d3ee",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230417185827.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "a4eec5ae61d39448309a842367786b0470a71ca7"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:36b84df44dacae992395ac9c5be52ca3320892ed4f272d27eb4332dfdb13d3ee",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230417185827.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "a4eec5ae61d39448309a842367786b0470a71ca7"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```