### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230417190122.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:b8abd9374ed5d4c93413f415c7b51f8f999fc5a3abdf3934a1b6cb836f1b4995
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230417190122.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 8bf058f46bc6516915b1e7efed9a8341dbb925b5
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b8abd9374ed5d4c93413f415c7b51f8f999fc5a3abdf3934a1b6cb836f1b4995",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230417190122.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "8bf058f46bc6516915b1e7efed9a8341dbb925b5"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b8abd9374ed5d4c93413f415c7b51f8f999fc5a3abdf3934a1b6cb836f1b4995",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230417190122.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "8bf058f46bc6516915b1e7efed9a8341dbb925b5"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```