### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230417193600.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:f0b4c7e1fd5ea832b9d5031801c975e6eb2403ea4f8a232945bf7e09a250cccf
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230417193600.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: cd6a83c17ec6f5fd0d063268b490e34fe234260e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f0b4c7e1fd5ea832b9d5031801c975e6eb2403ea4f8a232945bf7e09a250cccf",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230417193600.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "cd6a83c17ec6f5fd0d063268b490e34fe234260e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f0b4c7e1fd5ea832b9d5031801c975e6eb2403ea4f8a232945bf7e09a250cccf",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230417193600.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "cd6a83c17ec6f5fd0d063268b490e34fe234260e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```