### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230418152446.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:353f1fa05560e0ce7aa7a10d541340f63793cb3552f0f1f07d799bc62afea7f2
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230418152446.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 568743732dcb47cc576a178795b6a992923f1d3c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:353f1fa05560e0ce7aa7a10d541340f63793cb3552f0f1f07d799bc62afea7f2",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230418152446.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "568743732dcb47cc576a178795b6a992923f1d3c"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:353f1fa05560e0ce7aa7a10d541340f63793cb3552f0f1f07d799bc62afea7f2",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230418152446.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "568743732dcb47cc576a178795b6a992923f1d3c"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```