### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230421144248.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:471a995fc739f6c17722a510d23cee0f2b8e725b81e4d763cc656ea648977d13
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230421144248.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 7c2156083894c2d99fbfd69eff44fd53e9af28a1
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:471a995fc739f6c17722a510d23cee0f2b8e725b81e4d763cc656ea648977d13",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230421144248.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "7c2156083894c2d99fbfd69eff44fd53e9af28a1"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:471a995fc739f6c17722a510d23cee0f2b8e725b81e4d763cc656ea648977d13",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230421144248.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "7c2156083894c2d99fbfd69eff44fd53e9af28a1"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```