### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230421143741.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:39167485fdece781b33d08063499fd29cf4f880a9b751a0d70f4608c25825a67
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230421143741.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 35d71e6c2805310f4e2aef29a9b4eb69701bb29a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:39167485fdece781b33d08063499fd29cf4f880a9b751a0d70f4608c25825a67",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230421143741.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "35d71e6c2805310f4e2aef29a9b4eb69701bb29a"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:39167485fdece781b33d08063499fd29cf4f880a9b751a0d70f4608c25825a67",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230421143741.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "35d71e6c2805310f4e2aef29a9b4eb69701bb29a"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```