### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230502054622.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:0266f52d3e403adf8752e81d8524b1fcce56679dd506ca88b3b6dc34b76803d8
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230502054622.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 546c334848663f0a8632d56170d39177542ad4eb
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:0266f52d3e403adf8752e81d8524b1fcce56679dd506ca88b3b6dc34b76803d8",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230502054622.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "546c334848663f0a8632d56170d39177542ad4eb"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:0266f52d3e403adf8752e81d8524b1fcce56679dd506ca88b3b6dc34b76803d8",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230502054622.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "546c334848663f0a8632d56170d39177542ad4eb"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```