### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230502164137.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:95f6be62ccd55f697f9fb6863bf5087658c3d3c467a5bf3cccd421e575ec53a6
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230502164137.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: b185a310035c1304f6762db03c0e296ca4471588
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:95f6be62ccd55f697f9fb6863bf5087658c3d3c467a5bf3cccd421e575ec53a6",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230502164137.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "b185a310035c1304f6762db03c0e296ca4471588"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:95f6be62ccd55f697f9fb6863bf5087658c3d3c467a5bf3cccd421e575ec53a6",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230502164137.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "b185a310035c1304f6762db03c0e296ca4471588"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```