### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230502164952.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:f556327e9fb4d020495ffab859c366960fc331af5499ed237c0d28bfbf35a925
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230502164952.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: fe954a1a450b427b6f4da61acf71d2543721b9c0
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f556327e9fb4d020495ffab859c366960fc331af5499ed237c0d28bfbf35a925",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230502164952.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "fe954a1a450b427b6f4da61acf71d2543721b9c0"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f556327e9fb4d020495ffab859c366960fc331af5499ed237c0d28bfbf35a925",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230502164952.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "fe954a1a450b427b6f4da61acf71d2543721b9c0"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```