### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230511190448.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:78944ee169983a6834338a3375e262174e6983415c95bc8bfc41eecce4847098
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230511190448.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: dfbafeac1041f62c5881721ce20759a86302ef9d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:78944ee169983a6834338a3375e262174e6983415c95bc8bfc41eecce4847098",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230511190448.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "dfbafeac1041f62c5881721ce20759a86302ef9d"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:78944ee169983a6834338a3375e262174e6983415c95bc8bfc41eecce4847098",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230511190448.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "dfbafeac1041f62c5881721ce20759a86302ef9d"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```