### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230518170408.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:6f85653975a5eebc2fc922955f36532da549deb11696c78f20748b39a0c2fc16
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230518170408.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: ac1250a8f1f0bfe5c21912d2b0ff16213179553c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6f85653975a5eebc2fc922955f36532da549deb11696c78f20748b39a0c2fc16",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230518170408.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ac1250a8f1f0bfe5c21912d2b0ff16213179553c"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6f85653975a5eebc2fc922955f36532da549deb11696c78f20748b39a0c2fc16",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230518170408.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ac1250a8f1f0bfe5c21912d2b0ff16213179553c"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```