### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230518170541.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:133e79f7953a678890df96b7a76e6776fa12676d5e04d89d2ec0114cd1eee4ed
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230518170541.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 364d74ff49d55826aea85503a26d67caa31dcbed
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:133e79f7953a678890df96b7a76e6776fa12676d5e04d89d2ec0114cd1eee4ed",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230518170541.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "364d74ff49d55826aea85503a26d67caa31dcbed"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:133e79f7953a678890df96b7a76e6776fa12676d5e04d89d2ec0114cd1eee4ed",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230518170541.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "364d74ff49d55826aea85503a26d67caa31dcbed"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```