### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230519190704.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:7f66c927756965b43212e3b7a09a8b6423a47afe4da5ebf927897ac8fa3cd6fd
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230519190704.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: e56e9731ef4e207247532281590db8de31d732c7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7f66c927756965b43212e3b7a09a8b6423a47afe4da5ebf927897ac8fa3cd6fd",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230519190704.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "e56e9731ef4e207247532281590db8de31d732c7"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7f66c927756965b43212e3b7a09a8b6423a47afe4da5ebf927897ac8fa3cd6fd",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230519190704.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "e56e9731ef4e207247532281590db8de31d732c7"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```