### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230519230709.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:5ab9d4b01216f0bb82fbe829e9ccc066241f573db7f9d920a28a592a3a505599
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230519230709.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 8a1de2f34a1da62ee88d1e0c94eb6cf281be535d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5ab9d4b01216f0bb82fbe829e9ccc066241f573db7f9d920a28a592a3a505599",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230519230709.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "8a1de2f34a1da62ee88d1e0c94eb6cf281be535d"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5ab9d4b01216f0bb82fbe829e9ccc066241f573db7f9d920a28a592a3a505599",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230519230709.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "8a1de2f34a1da62ee88d1e0c94eb6cf281be535d"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```