### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230525213835.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:f9c574eeaafda012a8297dd1b55025c76f5ff7c52909a46595df54a49afe4729
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230525213835.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: cd7ae859d3bdea17dfb616efcd0f03e8b1e9db4a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f9c574eeaafda012a8297dd1b55025c76f5ff7c52909a46595df54a49afe4729",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230525213835.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "cd7ae859d3bdea17dfb616efcd0f03e8b1e9db4a"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f9c574eeaafda012a8297dd1b55025c76f5ff7c52909a46595df54a49afe4729",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230525213835.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "cd7ae859d3bdea17dfb616efcd0f03e8b1e9db4a"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```