### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230525213957.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:8c9464c68bf825aa410f4c0e3675cc325d0f338735cb21643645e9f6a7578d5d
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230525213957.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: ad7702eb2e8df595caa98c1af12b6465c211b41c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8c9464c68bf825aa410f4c0e3675cc325d0f338735cb21643645e9f6a7578d5d",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230525213957.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ad7702eb2e8df595caa98c1af12b6465c211b41c"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8c9464c68bf825aa410f4c0e3675cc325d0f338735cb21643645e9f6a7578d5d",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230525213957.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ad7702eb2e8df595caa98c1af12b6465c211b41c"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```