### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230525221808.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:cc42f0b38482ba793b7ddcea747b35ae0a2096fd46fd5a04e72f90529c3a9e93
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230525221808.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: e8649bb4681a4852066ed44f77e9d4a1205314a6
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cc42f0b38482ba793b7ddcea747b35ae0a2096fd46fd5a04e72f90529c3a9e93",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230525221808.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "e8649bb4681a4852066ed44f77e9d4a1205314a6"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cc42f0b38482ba793b7ddcea747b35ae0a2096fd46fd5a04e72f90529c3a9e93",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230525221808.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "e8649bb4681a4852066ed44f77e9d4a1205314a6"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```