### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230530174903.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:6e0b09f796475b4720b94d0540c021db67ecb5b612b21cadc6337190b0bc8814
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230530174903.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 36952cc28a5d055051376f616f5a2adcd441f69c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6e0b09f796475b4720b94d0540c021db67ecb5b612b21cadc6337190b0bc8814",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230530174903.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "36952cc28a5d055051376f616f5a2adcd441f69c"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6e0b09f796475b4720b94d0540c021db67ecb5b612b21cadc6337190b0bc8814",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230530174903.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "36952cc28a5d055051376f616f5a2adcd441f69c"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```