### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230602200130.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:56fc290ecdbd08c50b8a61356500be878755d4ff078d99c3fe470a9643fc6a0d
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230602200130.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 0f18f9aa4da0857ba44048a935a0052601b13388
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:56fc290ecdbd08c50b8a61356500be878755d4ff078d99c3fe470a9643fc6a0d",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230602200130.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "0f18f9aa4da0857ba44048a935a0052601b13388"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:56fc290ecdbd08c50b8a61356500be878755d4ff078d99c3fe470a9643fc6a0d",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230602200130.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "0f18f9aa4da0857ba44048a935a0052601b13388"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```