### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230602200306.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:ed0e201b555b12ed334c984b5bb851c07b0a87648af6169ecf3643c188e4cccf
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230602200306.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: f538b23c8010d339e58a55877d2a9fab4be0ac9e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ed0e201b555b12ed334c984b5bb851c07b0a87648af6169ecf3643c188e4cccf",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230602200306.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "f538b23c8010d339e58a55877d2a9fab4be0ac9e"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ed0e201b555b12ed334c984b5bb851c07b0a87648af6169ecf3643c188e4cccf",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230602200306.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "f538b23c8010d339e58a55877d2a9fab4be0ac9e"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```