### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230605201131.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:35639f5b2fbfd46d2bc19ed56c9eb93488035063e6b70b21a972aba279845e30
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230605201131.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: d1e0f9350a886dc378b258894303aa232281512b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:35639f5b2fbfd46d2bc19ed56c9eb93488035063e6b70b21a972aba279845e30",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230605201131.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "d1e0f9350a886dc378b258894303aa232281512b"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:35639f5b2fbfd46d2bc19ed56c9eb93488035063e6b70b21a972aba279845e30",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230605201131.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "d1e0f9350a886dc378b258894303aa232281512b"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```