### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230605201144.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:3618b4aa5d9395a71d2ceecd8f726ab7a196998f45f5c0203c4f50189708cdc2
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230605201144.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 4ac475e90ba1feca15ea82a2c301e10b3199207e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3618b4aa5d9395a71d2ceecd8f726ab7a196998f45f5c0203c4f50189708cdc2",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230605201144.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "4ac475e90ba1feca15ea82a2c301e10b3199207e"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3618b4aa5d9395a71d2ceecd8f726ab7a196998f45f5c0203c4f50189708cdc2",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230605201144.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "4ac475e90ba1feca15ea82a2c301e10b3199207e"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```