### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230605205102.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:cea41ab6440154abe22ee341ec0583e2e6454e0dc00f7874ae299545615fa4d9
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230605205102.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 107a4cc006cc34a6d57379464540792351c8781b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cea41ab6440154abe22ee341ec0583e2e6454e0dc00f7874ae299545615fa4d9",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230605205102.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "107a4cc006cc34a6d57379464540792351c8781b"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:cea41ab6440154abe22ee341ec0583e2e6454e0dc00f7874ae299545615fa4d9",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230605205102.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "107a4cc006cc34a6d57379464540792351c8781b"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```