### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230609142659.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:b89c412db882121142e437da9c465c8ca55474d46597f43b7b8391a13c8cde63
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230609142659.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 30692047c64944b97b7162141cd8a3d45316052d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b89c412db882121142e437da9c465c8ca55474d46597f43b7b8391a13c8cde63",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230609142659.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "30692047c64944b97b7162141cd8a3d45316052d"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b89c412db882121142e437da9c465c8ca55474d46597f43b7b8391a13c8cde63",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230609142659.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "30692047c64944b97b7162141cd8a3d45316052d"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```