### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230613055453.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:dd896039ad0a8be3d409d5aecbba5f4323efa834a8554103bac924cce71016d5
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230613055453.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 565e6452925d0bf7530669c2586d6013833df9e4
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:dd896039ad0a8be3d409d5aecbba5f4323efa834a8554103bac924cce71016d5",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230613055453.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "565e6452925d0bf7530669c2586d6013833df9e4"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:dd896039ad0a8be3d409d5aecbba5f4323efa834a8554103bac924cce71016d5",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230613055453.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "565e6452925d0bf7530669c2586d6013833df9e4"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```