### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230616094818.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:b0ed13c1db2b01b8bbf1ac6e51463a7552b99bbda8c0190254fea61713d86908
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230616094818.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: bf40abf63d2bc5bf2d4b89d202d29a5545a63f11
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b0ed13c1db2b01b8bbf1ac6e51463a7552b99bbda8c0190254fea61713d86908",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230616094818.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "bf40abf63d2bc5bf2d4b89d202d29a5545a63f11"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b0ed13c1db2b01b8bbf1ac6e51463a7552b99bbda8c0190254fea61713d86908",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230616094818.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "bf40abf63d2bc5bf2d4b89d202d29a5545a63f11"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```