### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230616094650.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:eaa3215a7bb8423e3c350a9f805fd8b6c7a6faf627fa55c2f539dcabadd2b328
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230616094650.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 4fa5ed48ac4438b0a1e8d1edcdfb507155e0b504
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:eaa3215a7bb8423e3c350a9f805fd8b6c7a6faf627fa55c2f539dcabadd2b328",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230616094650.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "4fa5ed48ac4438b0a1e8d1edcdfb507155e0b504"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:eaa3215a7bb8423e3c350a9f805fd8b6c7a6faf627fa55c2f539dcabadd2b328",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230616094650.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "4fa5ed48ac4438b0a1e8d1edcdfb507155e0b504"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```