### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230619025704.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:3012dc8ae866c8ea04c22d6bd3badf9d535c28e870b94cc915e70e793120c74b
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230619025704.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: e02e453041f55a5e85f25162ac048cafdbbd821d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3012dc8ae866c8ea04c22d6bd3badf9d535c28e870b94cc915e70e793120c74b",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230619025704.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "e02e453041f55a5e85f25162ac048cafdbbd821d"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3012dc8ae866c8ea04c22d6bd3badf9d535c28e870b94cc915e70e793120c74b",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230619025704.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "e02e453041f55a5e85f25162ac048cafdbbd821d"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```