### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230626171049.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:c725bd44e5d522c7f200cc13c6acbd6cafa3791c339f2b85ea3abe3a43fa8aa0
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230626171049.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 93779d74913d705f289f7dcb59cae94707d67c6b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c725bd44e5d522c7f200cc13c6acbd6cafa3791c339f2b85ea3abe3a43fa8aa0",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230626171049.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "93779d74913d705f289f7dcb59cae94707d67c6b"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c725bd44e5d522c7f200cc13c6acbd6cafa3791c339f2b85ea3abe3a43fa8aa0",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230626171049.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "93779d74913d705f289f7dcb59cae94707d67c6b"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```