### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230626171212.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:c01507c434980ad6c35c866ab55ab2c0ae0e9c9bfdaeed6d91512b3f5a291086
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230626171212.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: efe816af358e7889ab8ac3982b1a16890b89d3dd
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c01507c434980ad6c35c866ab55ab2c0ae0e9c9bfdaeed6d91512b3f5a291086",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230626171212.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "efe816af358e7889ab8ac3982b1a16890b89d3dd"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c01507c434980ad6c35c866ab55ab2c0ae0e9c9bfdaeed6d91512b3f5a291086",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230626171212.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "efe816af358e7889ab8ac3982b1a16890b89d3dd"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```