### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230626171436.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:2d34ba8d2fde7d76719a6ca4837b8992b13c83db160aca4cb60f158e51506c36
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230626171436.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 068900345d1bf12cd1959644a61fa3faff131a25
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2d34ba8d2fde7d76719a6ca4837b8992b13c83db160aca4cb60f158e51506c36",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230626171436.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "068900345d1bf12cd1959644a61fa3faff131a25"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2d34ba8d2fde7d76719a6ca4837b8992b13c83db160aca4cb60f158e51506c36",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230626171436.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "068900345d1bf12cd1959644a61fa3faff131a25"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```