### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230627132629.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:254883680b6fd7666fab3731e6b3f2d0224b0e17f41d1e5021fc15909a34b2ab
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230627132629.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 4db1b9d37f510facb485fd720ec95f29f703fbf7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:254883680b6fd7666fab3731e6b3f2d0224b0e17f41d1e5021fc15909a34b2ab",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230627132629.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "4db1b9d37f510facb485fd720ec95f29f703fbf7"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:254883680b6fd7666fab3731e6b3f2d0224b0e17f41d1e5021fc15909a34b2ab",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230627132629.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "4db1b9d37f510facb485fd720ec95f29f703fbf7"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```