### PR TITLE
chore(cd): update dinghy version to 2023.06.28.13.57.31.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -24,15 +24,15 @@ services:
       sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
   dinghy:
     image:
-      imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b
+      imageId: sha256:681e974fbbdd667fe8f37aa3f6a2005b4c2753ddbdff49289cb01a562fc259c8
       repository: armory/dinghy
-      tag: 2022.08.25.17.05.13.master
+      tag: 2023.06.28.13.57.31.master
     vcs:
       repo:
         orgName: armory-io
         repoName: dinghy
         type: github
-      sha: 168ddc21ba83b6e634f998b339b458c82ba27420
+      sha: b5a6245064f472384c17bb0b5e879739f682ce3c
   echo:
     image:
       imageId: sha256:cc4a6c2c98458231591e275c516a9beda32461613bde222ff9bb67ee69bfe078


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:681e974fbbdd667fe8f37aa3f6a2005b4c2753ddbdff49289cb01a562fc259c8",
        "repository": "armory/dinghy",
        "tag": "2023.06.28.13.57.31.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "dinghy",
          "type": "github"
        },
        "sha": "b5a6245064f472384c17bb0b5e879739f682ce3c"
      }
    },
    "name": "dinghy"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:681e974fbbdd667fe8f37aa3f6a2005b4c2753ddbdff49289cb01a562fc259c8",
        "repository": "armory/dinghy",
        "tag": "2023.06.28.13.57.31.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "dinghy",
          "type": "github"
        },
        "sha": "b5a6245064f472384c17bb0b5e879739f682ce3c"
      }
    },
    "name": "dinghy"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```