### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230628200644.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:2bceb62288222a9c593404622af9f7f3c701d1c20f31fb08f88a1416350d60ec
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230628200644.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: fff621ad5ecfbb6b973b001567aa37eda83c7f0e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2bceb62288222a9c593404622af9f7f3c701d1c20f31fb08f88a1416350d60ec",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230628200644.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "fff621ad5ecfbb6b973b001567aa37eda83c7f0e"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2bceb62288222a9c593404622af9f7f3c701d1c20f31fb08f88a1416350d60ec",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230628200644.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "fff621ad5ecfbb6b973b001567aa37eda83c7f0e"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```