### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230703181428.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:4f4618041cc79855c378895ecd429f0ac359c65bddbb57a2f0096cea407c594d
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230703181428.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 6d9299a53cfc83c685de1818e26f65d4dd5e75a3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4f4618041cc79855c378895ecd429f0ac359c65bddbb57a2f0096cea407c594d",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230703181428.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "6d9299a53cfc83c685de1818e26f65d4dd5e75a3"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4f4618041cc79855c378895ecd429f0ac359c65bddbb57a2f0096cea407c594d",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230703181428.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "6d9299a53cfc83c685de1818e26f65d4dd5e75a3"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```