### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230706175448.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:70ddbf51b9304965b7bdcdfc82004778a536bb5ebfd8c599d0e8103e0ebf3435
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230706175448.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 8a91b5395656d7009a4d74941c0a119415066126
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:70ddbf51b9304965b7bdcdfc82004778a536bb5ebfd8c599d0e8103e0ebf3435",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230706175448.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "8a91b5395656d7009a4d74941c0a119415066126"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:70ddbf51b9304965b7bdcdfc82004778a536bb5ebfd8c599d0e8103e0ebf3435",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230706175448.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "8a91b5395656d7009a4d74941c0a119415066126"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```