### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230712164841.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:2bcdcc02e2fd16629cfd2c19c21327829bba24a8cea6df47eada06a86d7fe741
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230712164841.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: a0531b11c7ffa4f238d6fd026b955eb6ba0f0785
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2bcdcc02e2fd16629cfd2c19c21327829bba24a8cea6df47eada06a86d7fe741",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230712164841.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "a0531b11c7ffa4f238d6fd026b955eb6ba0f0785"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2bcdcc02e2fd16629cfd2c19c21327829bba24a8cea6df47eada06a86d7fe741",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230712164841.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "a0531b11c7ffa4f238d6fd026b955eb6ba0f0785"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```