### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230712221552.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:a05189a78b8220df4d33b0dc8485e1199abc2aa55efa964c252306bfc03950b1
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230712221552.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: bdc1e9d1e780710f4646a0ed9e4c9c42f7877ff4
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a05189a78b8220df4d33b0dc8485e1199abc2aa55efa964c252306bfc03950b1",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230712221552.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "bdc1e9d1e780710f4646a0ed9e4c9c42f7877ff4"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a05189a78b8220df4d33b0dc8485e1199abc2aa55efa964c252306bfc03950b1",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230712221552.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "bdc1e9d1e780710f4646a0ed9e4c9c42f7877ff4"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```