### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230718213612.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:5f938996b7014523b0bf81ab9d0af5de2995d026651324b2be826b46e9b9a1e7
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230718213612.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 73a1dbaafd1680f4a6fccecd2cfb29afb4e29cac
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5f938996b7014523b0bf81ab9d0af5de2995d026651324b2be826b46e9b9a1e7",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230718213612.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "73a1dbaafd1680f4a6fccecd2cfb29afb4e29cac"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5f938996b7014523b0bf81ab9d0af5de2995d026651324b2be826b46e9b9a1e7",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230718213612.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "73a1dbaafd1680f4a6fccecd2cfb29afb4e29cac"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```