### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230810191257.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:202e7003554399d8c07d2a960f1b7082c166c9b449496ab5f711c37ddd7e4e72
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230810191257.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: d6146dcf2d4eb090f3b6e7ee4c5f4a915c614c5d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:202e7003554399d8c07d2a960f1b7082c166c9b449496ab5f711c37ddd7e4e72",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230810191257.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "d6146dcf2d4eb090f3b6e7ee4c5f4a915c614c5d"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:202e7003554399d8c07d2a960f1b7082c166c9b449496ab5f711c37ddd7e4e72",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230810191257.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "d6146dcf2d4eb090f3b6e7ee4c5f4a915c614c5d"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```