### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230810205009.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:56be9083175f634cff5d70071c28124a4f4c0230b7adc095c012d24bdc99ed4e
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230810205009.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 58becfe22e71b827cad845edfd8afac3ed8a5ac4
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:56be9083175f634cff5d70071c28124a4f4c0230b7adc095c012d24bdc99ed4e",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230810205009.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "58becfe22e71b827cad845edfd8afac3ed8a5ac4"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:56be9083175f634cff5d70071c28124a4f4c0230b7adc095c012d24bdc99ed4e",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230810205009.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "58becfe22e71b827cad845edfd8afac3ed8a5ac4"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```