### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230810205113.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:1f0bd89ec61e7baee6347496f73048363c8ba533f4810de7a2a1116feffadbb9
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230810205113.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 9affd98c2670f617eca0e35d688ebd8028b8c8ef
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:1f0bd89ec61e7baee6347496f73048363c8ba533f4810de7a2a1116feffadbb9",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230810205113.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "9affd98c2670f617eca0e35d688ebd8028b8c8ef"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:1f0bd89ec61e7baee6347496f73048363c8ba533f4810de7a2a1116feffadbb9",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230810205113.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "9affd98c2670f617eca0e35d688ebd8028b8c8ef"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```