### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230811170432.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:f5165639c438d21351b779143a20b3fa97dd8e169e3a85059df68cf4f8c1a6cb
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230811170432.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: ae46e3c8175dde65b3b557a148bb26c48b6c35d5
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f5165639c438d21351b779143a20b3fa97dd8e169e3a85059df68cf4f8c1a6cb",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230811170432.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "ae46e3c8175dde65b3b557a148bb26c48b6c35d5"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f5165639c438d21351b779143a20b3fa97dd8e169e3a85059df68cf4f8c1a6cb",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230811170432.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "ae46e3c8175dde65b3b557a148bb26c48b6c35d5"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```