### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230811170806.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:fd436fcc526464c0d8337c04490d3483cb98bb43976905fc8f9a79bc66032bd7
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230811170806.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: cb0a20f15743b6da87f2f9498893f6e033214098
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fd436fcc526464c0d8337c04490d3483cb98bb43976905fc8f9a79bc66032bd7",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230811170806.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "cb0a20f15743b6da87f2f9498893f6e033214098"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fd436fcc526464c0d8337c04490d3483cb98bb43976905fc8f9a79bc66032bd7",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230811170806.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "cb0a20f15743b6da87f2f9498893f6e033214098"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```