### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230811170616.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:65a898bcb4c4de5ac69e2f3709ce8578556ff2ce13990871d963cefb21969fbf
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230811170616.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: a72b87ba07d3e80192b408610a764f846cd727c6
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:65a898bcb4c4de5ac69e2f3709ce8578556ff2ce13990871d963cefb21969fbf",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230811170616.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "a72b87ba07d3e80192b408610a764f846cd727c6"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:65a898bcb4c4de5ac69e2f3709ce8578556ff2ce13990871d963cefb21969fbf",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230811170616.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "a72b87ba07d3e80192b408610a764f846cd727c6"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```