### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230814084608.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:b79fd460226c4029940f4522af789395fd8221d1a8a8c3a31485976d850ecc66
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230814084608.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: f57df150573ed2eb1e5866f56d6de76587616cca
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b79fd460226c4029940f4522af789395fd8221d1a8a8c3a31485976d850ecc66",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230814084608.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "f57df150573ed2eb1e5866f56d6de76587616cca"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b79fd460226c4029940f4522af789395fd8221d1a8a8c3a31485976d850ecc66",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230814084608.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "f57df150573ed2eb1e5866f56d6de76587616cca"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```