### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230824155851.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:73d429a228c12e02414a0818802907f988860cc645b164b64955df5d723641e2
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230824155851.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: f0544dc27924bbb3a1686f56b09b3134d36453d8
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:73d429a228c12e02414a0818802907f988860cc645b164b64955df5d723641e2",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230824155851.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "f0544dc27924bbb3a1686f56b09b3134d36453d8"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:73d429a228c12e02414a0818802907f988860cc645b164b64955df5d723641e2",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230824155851.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "f0544dc27924bbb3a1686f56b09b3134d36453d8"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```