### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230824160206.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:dd6cba55d26731c2fd21279dada8259ad15dede87a525bd6c2ab578358d81504
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230824160206.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: ac6ed786440a7229162fb0c92683304581d9fab7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:dd6cba55d26731c2fd21279dada8259ad15dede87a525bd6c2ab578358d81504",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230824160206.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ac6ed786440a7229162fb0c92683304581d9fab7"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:dd6cba55d26731c2fd21279dada8259ad15dede87a525bd6c2ab578358d81504",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230824160206.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "ac6ed786440a7229162fb0c92683304581d9fab7"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```