### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20230829181232.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:3cc3c247807d87f1b856823a6a0d421e0fbce426a20b1caa127a48ea280e39a7
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20230829181232.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: c24b570673fc0f441a65fb69f6936027905c686d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3cc3c247807d87f1b856823a6a0d421e0fbce426a20b1caa127a48ea280e39a7",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230829181232.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "c24b570673fc0f441a65fb69f6936027905c686d"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:3cc3c247807d87f1b856823a6a0d421e0fbce426a20b1caa127a48ea280e39a7",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20230829181232.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "c24b570673fc0f441a65fb69f6936027905c686d"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```