### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230906155958.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:4553f168a8809dcc2302796a121278cdda5a9936700034b020b9a761cb169ea6
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230906155958.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: c76bd5af68dcc16a73c56fce10ce8dbd6ab41104
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4553f168a8809dcc2302796a121278cdda5a9936700034b020b9a761cb169ea6",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230906155958.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "c76bd5af68dcc16a73c56fce10ce8dbd6ab41104"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4553f168a8809dcc2302796a121278cdda5a9936700034b020b9a761cb169ea6",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230906155958.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "c76bd5af68dcc16a73c56fce10ce8dbd6ab41104"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```