### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230906160439.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:135374090951f57cebb1cb1371a9c3187737c3bb1b1d05b112ec0f651d2a9a90
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230906160439.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 759b552ce831a0f2cb75158c0a3d3fed6bcc9570
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:135374090951f57cebb1cb1371a9c3187737c3bb1b1d05b112ec0f651d2a9a90",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230906160439.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "759b552ce831a0f2cb75158c0a3d3fed6bcc9570"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:135374090951f57cebb1cb1371a9c3187737c3bb1b1d05b112ec0f651d2a9a90",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230906160439.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "759b552ce831a0f2cb75158c0a3d3fed6bcc9570"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```