### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230906164403.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:7acef2c15661d5f01793ba9b556f0dccfce71c35336aee897ffbd91e2132bad9
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230906164403.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: ae834e9ed9aa4fbef1fcbb01f1f9b0abacd325c3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7acef2c15661d5f01793ba9b556f0dccfce71c35336aee897ffbd91e2132bad9",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230906164403.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "ae834e9ed9aa4fbef1fcbb01f1f9b0abacd325c3"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7acef2c15661d5f01793ba9b556f0dccfce71c35336aee897ffbd91e2132bad9",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230906164403.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "ae834e9ed9aa4fbef1fcbb01f1f9b0abacd325c3"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```