### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230906183424.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:d3c6479cedad49d77ac0005d2305cba20f15d6459cad6dda364b82c28550b654
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230906183424.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 98581311d63a17636d85681e90c222c5e8c2a017
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d3c6479cedad49d77ac0005d2305cba20f15d6459cad6dda364b82c28550b654",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230906183424.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "98581311d63a17636d85681e90c222c5e8c2a017"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d3c6479cedad49d77ac0005d2305cba20f15d6459cad6dda364b82c28550b654",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230906183424.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "98581311d63a17636d85681e90c222c5e8c2a017"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```