### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20230914181351.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:fec5d0a6476a1aa419f19f05111891214e18ee59522765469a0fc4cd60719d8f
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20230914181351.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: e8eea5221d8cc65387f09bb6acfa9e6f41d44629
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fec5d0a6476a1aa419f19f05111891214e18ee59522765469a0fc4cd60719d8f",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230914181351.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "e8eea5221d8cc65387f09bb6acfa9e6f41d44629"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fec5d0a6476a1aa419f19f05111891214e18ee59522765469a0fc4cd60719d8f",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20230914181351.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "e8eea5221d8cc65387f09bb6acfa9e6f41d44629"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```