### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230920161651.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:5c4ec3dece39be554c59755d54f71f1061e4fbffd154279319cc88e55c50e1eb
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230920161651.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 32b0df9b784811009377571116855b549889718a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5c4ec3dece39be554c59755d54f71f1061e4fbffd154279319cc88e55c50e1eb",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230920161651.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "32b0df9b784811009377571116855b549889718a"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5c4ec3dece39be554c59755d54f71f1061e4fbffd154279319cc88e55c50e1eb",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230920161651.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "32b0df9b784811009377571116855b549889718a"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```