### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230921193452.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:79a69734921a2a75e76f2a4d9dcf8e1aa18c913cf89b1966ecc0910bb97c70c5
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230921193452.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 12dc010660501b8620ba8857675bfee1c7638939
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:79a69734921a2a75e76f2a4d9dcf8e1aa18c913cf89b1966ecc0910bb97c70c5",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230921193452.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "12dc010660501b8620ba8857675bfee1c7638939"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:79a69734921a2a75e76f2a4d9dcf8e1aa18c913cf89b1966ecc0910bb97c70c5",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230921193452.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "12dc010660501b8620ba8857675bfee1c7638939"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```