### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20230922154645.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:4a7e9f754ffc3b8f992655896ddefd30a4b7b16e1314221a987f8c634714b31f
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20230922154645.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 61699656ec37644c629388bcd6013d132d6d2e4c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4a7e9f754ffc3b8f992655896ddefd30a4b7b16e1314221a987f8c634714b31f",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230922154645.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "61699656ec37644c629388bcd6013d132d6d2e4c"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:4a7e9f754ffc3b8f992655896ddefd30a4b7b16e1314221a987f8c634714b31f",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20230922154645.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "61699656ec37644c629388bcd6013d132d6d2e4c"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```