### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230926021146.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:f08df42362568489978e31976daf01827124842da3d3a15f5429f02f008dc0a5
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230926021146.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 4a8471feb901d81ca833bd6774ad073287375fef
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f08df42362568489978e31976daf01827124842da3d3a15f5429f02f008dc0a5",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230926021146.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "4a8471feb901d81ca833bd6774ad073287375fef"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f08df42362568489978e31976daf01827124842da3d3a15f5429f02f008dc0a5",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230926021146.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "4a8471feb901d81ca833bd6774ad073287375fef"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```