### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20230927034628.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:c9eeae5ccc2c82d0eff886601d7435a0bb72801d71f7a350740cb4d7322a7d06
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20230927034628.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 3be8c4504e6f9287a86d1316f07a8e29ce54d278
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c9eeae5ccc2c82d0eff886601d7435a0bb72801d71f7a350740cb4d7322a7d06",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230927034628.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "3be8c4504e6f9287a86d1316f07a8e29ce54d278"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c9eeae5ccc2c82d0eff886601d7435a0bb72801d71f7a350740cb4d7322a7d06",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20230927034628.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "3be8c4504e6f9287a86d1316f07a8e29ce54d278"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```