### PR TITLE
chore(cd): update terraformer version to 2023.09.28.21.40.45.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -123,12 +123,12 @@ services:
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
   terraformer:
     image:
-      imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a
+      imageId: sha256:c381756934162233635e0b6dc3b015882660dbc98c32f37fdb91b77fda705b58
       repository: armory/terraformer
-      tag: 2022.08.15.08.23.24.master
+      tag: 2023.09.28.21.40.45.master
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 06274aea2918f7e47222856537224de91c9cf542
+      sha: 116e4e5973a03d341c43f4b460e2520dbdc72c36


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c381756934162233635e0b6dc3b015882660dbc98c32f37fdb91b77fda705b58",
        "repository": "armory/terraformer",
        "tag": "2023.09.28.21.40.45.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "116e4e5973a03d341c43f4b460e2520dbdc72c36"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c381756934162233635e0b6dc3b015882660dbc98c32f37fdb91b77fda705b58",
        "repository": "armory/terraformer",
        "tag": "2023.09.28.21.40.45.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "116e4e5973a03d341c43f4b460e2520dbdc72c36"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```