### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20230929155147.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:fcf91064da1d868284456c75889274987d52ccd3b23ceb7c8575c6774dd80822
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20230929155147.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 301b9808e98e8927f6de2440881f848d888f709e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fcf91064da1d868284456c75889274987d52ccd3b23ceb7c8575c6774dd80822",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230929155147.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "301b9808e98e8927f6de2440881f848d888f709e"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fcf91064da1d868284456c75889274987d52ccd3b23ceb7c8575c6774dd80822",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20230929155147.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "301b9808e98e8927f6de2440881f848d888f709e"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```