### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20231001163735.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:d9275cfd94f5e721c5d1684201ed126027ba6dee2aba7beacedca8a827b95688
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20231001163735.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: f2a8c66d071d2cc7a1b0fcd26c89ff58e64b7be9
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d9275cfd94f5e721c5d1684201ed126027ba6dee2aba7beacedca8a827b95688",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231001163735.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "f2a8c66d071d2cc7a1b0fcd26c89ff58e64b7be9"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d9275cfd94f5e721c5d1684201ed126027ba6dee2aba7beacedca8a827b95688",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231001163735.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "f2a8c66d071d2cc7a1b0fcd26c89ff58e64b7be9"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```