### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20231002100607.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:f5dd8813411466f1d5f7bd06b74db8c27e507ddcd36dabd723fff3dd4c41a461
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20231002100607.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 0ab9907eb17c2180575effa6c6273293da9df037
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f5dd8813411466f1d5f7bd06b74db8c27e507ddcd36dabd723fff3dd4c41a461",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231002100607.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "0ab9907eb17c2180575effa6c6273293da9df037"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f5dd8813411466f1d5f7bd06b74db8c27e507ddcd36dabd723fff3dd4c41a461",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231002100607.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "0ab9907eb17c2180575effa6c6273293da9df037"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```