### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20231003010745.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:2e1ac6f5a0b2b74272a5a71ffbb67a44db793074e510034123c00902dcf69354
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20231003010745.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: d8a5beb0df35ba5f93d72257b25c178e2e743977
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2e1ac6f5a0b2b74272a5a71ffbb67a44db793074e510034123c00902dcf69354",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231003010745.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "d8a5beb0df35ba5f93d72257b25c178e2e743977"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2e1ac6f5a0b2b74272a5a71ffbb67a44db793074e510034123c00902dcf69354",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231003010745.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "d8a5beb0df35ba5f93d72257b25c178e2e743977"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```