### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231004164647.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:0f2c2578f80ded39db815e6652c4bb27c016aa76f00c83482383d4877fac1a69
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231004164647.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: d22be37b46e06abf5169a7f328390132553b7937
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:0f2c2578f80ded39db815e6652c4bb27c016aa76f00c83482383d4877fac1a69",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231004164647.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "d22be37b46e06abf5169a7f328390132553b7937"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:0f2c2578f80ded39db815e6652c4bb27c016aa76f00c83482383d4877fac1a69",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231004164647.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "d22be37b46e06abf5169a7f328390132553b7937"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```