### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231009150907.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:7bf0c6e3db8645f82aa4a44aaecb1e6363041b4d098b673caf31ba7cd641ccdd
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231009150907.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 12939454d3d2389a34758f3acf7b19d9fb1d3be8
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7bf0c6e3db8645f82aa4a44aaecb1e6363041b4d098b673caf31ba7cd641ccdd",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231009150907.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "12939454d3d2389a34758f3acf7b19d9fb1d3be8"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7bf0c6e3db8645f82aa4a44aaecb1e6363041b4d098b673caf31ba7cd641ccdd",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231009150907.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "12939454d3d2389a34758f3acf7b19d9fb1d3be8"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```