### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20231017200746.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:60b106d76a3b5d27709c555ec6b5f97c610fd1032c5df153f9d2c4de3ae5e229
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20231017200746.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 9be242a264fd6defed21b8eb43b418d0b43caea4
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:60b106d76a3b5d27709c555ec6b5f97c610fd1032c5df153f9d2c4de3ae5e229",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231017200746.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "9be242a264fd6defed21b8eb43b418d0b43caea4"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:60b106d76a3b5d27709c555ec6b5f97c610fd1032c5df153f9d2c4de3ae5e229",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231017200746.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "9be242a264fd6defed21b8eb43b418d0b43caea4"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```