### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20231017200622.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:2d35f6aeeee90ac6d2c6a0ee824fdc220061e444e4b07388a87045aefbf68aa9
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20231017200622.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 5345fe30ed63fdfea53d2d99c4a57844961bea65
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2d35f6aeeee90ac6d2c6a0ee824fdc220061e444e4b07388a87045aefbf68aa9",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231017200622.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "5345fe30ed63fdfea53d2d99c4a57844961bea65"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2d35f6aeeee90ac6d2c6a0ee824fdc220061e444e4b07388a87045aefbf68aa9",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231017200622.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "5345fe30ed63fdfea53d2d99c4a57844961bea65"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```