### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20231020174108.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:5e1065a5d380e453b52a2e3af12a1a4c1c21bd57067b875885a85be6236ca82a
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20231020174108.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 438da5041d9441eabbf62a5b313b2e23fa7ae917
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5e1065a5d380e453b52a2e3af12a1a4c1c21bd57067b875885a85be6236ca82a",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231020174108.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "438da5041d9441eabbf62a5b313b2e23fa7ae917"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5e1065a5d380e453b52a2e3af12a1a4c1c21bd57067b875885a85be6236ca82a",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231020174108.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "438da5041d9441eabbf62a5b313b2e23fa7ae917"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```