### PR TITLE
chore(cd): update terraformer version to 2023.10.27.17.07.10.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -123,12 +123,12 @@ services:
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
   terraformer:
     image:
-      imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a
+      imageId: sha256:94c508a1ecf42caa4affa04b70e630a82d75060d7d39aae639ccd46836824fe4
       repository: armory/terraformer
-      tag: 2022.08.15.08.23.24.master
+      tag: 2023.10.27.17.07.10.master
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 06274aea2918f7e47222856537224de91c9cf542
+      sha: 163f689d9cc36d701bfb66ac5a0d3b38128d5afa


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:94c508a1ecf42caa4affa04b70e630a82d75060d7d39aae639ccd46836824fe4",
        "repository": "armory/terraformer",
        "tag": "2023.10.27.17.07.10.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "163f689d9cc36d701bfb66ac5a0d3b38128d5afa"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:94c508a1ecf42caa4affa04b70e630a82d75060d7d39aae639ccd46836824fe4",
        "repository": "armory/terraformer",
        "tag": "2023.10.27.17.07.10.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "163f689d9cc36d701bfb66ac5a0d3b38128d5afa"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```