### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20231030001025.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:c74513428ff1a8cb87443e2267da7132666352ea76f84543be8c09f531309b55
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20231030001025.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: f9414f86479078f14cc3aaba28709359c6f68bce
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c74513428ff1a8cb87443e2267da7132666352ea76f84543be8c09f531309b55",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231030001025.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "f9414f86479078f14cc3aaba28709359c6f68bce"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c74513428ff1a8cb87443e2267da7132666352ea76f84543be8c09f531309b55",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231030001025.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "f9414f86479078f14cc3aaba28709359c6f68bce"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```