### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20231102195216.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:6a29373d8db271488f9ed115bebe9e49de720fc1b68a3e29b98bb5729f6a783d
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20231102195216.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: b64c9ea249bd262c84a7421faf071cabdd3fdf77
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6a29373d8db271488f9ed115bebe9e49de720fc1b68a3e29b98bb5729f6a783d",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231102195216.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "b64c9ea249bd262c84a7421faf071cabdd3fdf77"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6a29373d8db271488f9ed115bebe9e49de720fc1b68a3e29b98bb5729f6a783d",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231102195216.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "b64c9ea249bd262c84a7421faf071cabdd3fdf77"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```