### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20231102195635.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:a09705d86469e1c4a4e4da99000e645e00378717baaefaa90fee0f2942661c2c
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20231102195635.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: e79565522e3cb2598623556db8cd3861e6c045a6
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a09705d86469e1c4a4e4da99000e645e00378717baaefaa90fee0f2942661c2c",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231102195635.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "e79565522e3cb2598623556db8cd3861e6c045a6"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a09705d86469e1c4a4e4da99000e645e00378717baaefaa90fee0f2942661c2c",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231102195635.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "e79565522e3cb2598623556db8cd3861e6c045a6"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```