### PR TITLE
chore(cd): update spinnaker-rosco version to 2023.0.0-20231102195428.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-rosco:
+    image:
+      imageId: sha256:7fa67110cce001f9be26e14ccbecbdfd4546628e01b4ed2426dc3e3b0a556ac4
+      repository: armory/spinnaker-rosco
+      tag: 2023.0.0-20231102195428.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: rosco
+        type: github
+      sha: 0c0c97eb5f6bbd47eac194a32466fd7572f61a88
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7fa67110cce001f9be26e14ccbecbdfd4546628e01b4ed2426dc3e3b0a556ac4",
        "repository": "armory/spinnaker-rosco",
        "tag": "2023.0.0-20231102195428.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "0c0c97eb5f6bbd47eac194a32466fd7572f61a88"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7fa67110cce001f9be26e14ccbecbdfd4546628e01b4ed2426dc3e3b0a556ac4",
        "repository": "armory/spinnaker-rosco",
        "tag": "2023.0.0-20231102195428.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "0c0c97eb5f6bbd47eac194a32466fd7572f61a88"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```