### PR TITLE
chore(cd): update spinnaker-orca version to 2023.0.0-20231102200241.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:f16604af935fa1873f1ac33d04a10635fa7f89846b5d5eda76e8e7de12d0e0ac
+      repository: armory/spinnaker-orca
+      tag: 2023.0.0-20231102200241.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: 2e8ebf811073b3c2100712e16a2cf68fb675ec00
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f16604af935fa1873f1ac33d04a10635fa7f89846b5d5eda76e8e7de12d0e0ac",
        "repository": "armory/spinnaker-orca",
        "tag": "2023.0.0-20231102200241.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "2e8ebf811073b3c2100712e16a2cf68fb675ec00"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f16604af935fa1873f1ac33d04a10635fa7f89846b5d5eda76e8e7de12d0e0ac",
        "repository": "armory/spinnaker-orca",
        "tag": "2023.0.0-20231102200241.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "2e8ebf811073b3c2100712e16a2cf68fb675ec00"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```