### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231102202625.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:ca3491750b79a3a4bb53a14b5cfacf10a8735fceef4f05e4abfddaf437cdc3ab
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231102202625.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 023ff65d9217abcb3d78f3b6e72357a65db01463
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ca3491750b79a3a4bb53a14b5cfacf10a8735fceef4f05e4abfddaf437cdc3ab",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231102202625.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "023ff65d9217abcb3d78f3b6e72357a65db01463"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ca3491750b79a3a4bb53a14b5cfacf10a8735fceef4f05e4abfddaf437cdc3ab",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231102202625.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "023ff65d9217abcb3d78f3b6e72357a65db01463"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```