### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20231106164158.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:429665be1f50b3b3f83d314d3f73db40e3bd34510361370a2edcb382e6996663
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20231106164158.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: f748e0343b170b12beee7b2eeff9ec7802f37484
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:429665be1f50b3b3f83d314d3f73db40e3bd34510361370a2edcb382e6996663",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231106164158.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "f748e0343b170b12beee7b2eeff9ec7802f37484"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:429665be1f50b3b3f83d314d3f73db40e3bd34510361370a2edcb382e6996663",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231106164158.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "f748e0343b170b12beee7b2eeff9ec7802f37484"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```