### PR TITLE
chore(cd): update spinnaker-orca version to 2023.0.0-20231106180614.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:508677f8545825be7178a95daaa49b1081a0d556a0b3ea2670c9e1e8abb6bf2f
+      repository: armory/spinnaker-orca
+      tag: 2023.0.0-20231106180614.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: 645059dc2a487fbfaf9ab31b5f2d25b4265bfcb5
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:508677f8545825be7178a95daaa49b1081a0d556a0b3ea2670c9e1e8abb6bf2f",
        "repository": "armory/spinnaker-orca",
        "tag": "2023.0.0-20231106180614.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "645059dc2a487fbfaf9ab31b5f2d25b4265bfcb5"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:508677f8545825be7178a95daaa49b1081a0d556a0b3ea2670c9e1e8abb6bf2f",
        "repository": "armory/spinnaker-orca",
        "tag": "2023.0.0-20231106180614.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "645059dc2a487fbfaf9ab31b5f2d25b4265bfcb5"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```