### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231108151017.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:fd23c49b3ac6f3627817488f3124df29c3fa0bbb45300213632b111a999ff261
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231108151017.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 8825c133897ae962c9de674ef5cf1b6f9fe8a3c6
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fd23c49b3ac6f3627817488f3124df29c3fa0bbb45300213632b111a999ff261",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231108151017.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "8825c133897ae962c9de674ef5cf1b6f9fe8a3c6"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fd23c49b3ac6f3627817488f3124df29c3fa0bbb45300213632b111a999ff261",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231108151017.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "8825c133897ae962c9de674ef5cf1b6f9fe8a3c6"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```