### PR TITLE
chore(cd): update deck-armory version to 2023.11.10.02.52.39.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:a933411bca706441c2fdc55821ce6c37c72decb9c3d99a2f1442757b7059b99e
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2023.11.10.02.52.39.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: b6840e2cc79a889dd52a8a5fea6bcaadea93e0fb
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "5c1ebfdf924e73aa6877943cb008c216177b8256"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:a933411bca706441c2fdc55821ce6c37c72decb9c3d99a2f1442757b7059b99e",
        "repository": "armory/deck-armory",
        "tag": "2023.11.10.02.52.39.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "b6840e2cc79a889dd52a8a5fea6bcaadea93e0fb"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "5c1ebfdf924e73aa6877943cb008c216177b8256"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:a933411bca706441c2fdc55821ce6c37c72decb9c3d99a2f1442757b7059b99e",
        "repository": "armory/deck-armory",
        "tag": "2023.11.10.02.52.39.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "b6840e2cc79a889dd52a8a5fea6bcaadea93e0fb"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```