### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20231110195112.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:8823ecd7672edb7569445cc8ec4fe922ea5aa68876525c517578464bc28a9cb0
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20231110195112.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: e562d44deb3872a4ab78756d116c9c1e42f4d46b
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8823ecd7672edb7569445cc8ec4fe922ea5aa68876525c517578464bc28a9cb0",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231110195112.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "e562d44deb3872a4ab78756d116c9c1e42f4d46b"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8823ecd7672edb7569445cc8ec4fe922ea5aa68876525c517578464bc28a9cb0",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231110195112.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "e562d44deb3872a4ab78756d116c9c1e42f4d46b"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```