### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231110202835.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:5dc93e4f7dc47114e75886ac230b1347527ffd43e0a4b1347d0a07dedc47ebf8
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231110202835.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 27c44562fc9d29fa1e711b619c4c5880e80c5ef8
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5dc93e4f7dc47114e75886ac230b1347527ffd43e0a4b1347d0a07dedc47ebf8",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231110202835.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "27c44562fc9d29fa1e711b619c4c5880e80c5ef8"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5dc93e4f7dc47114e75886ac230b1347527ffd43e0a4b1347d0a07dedc47ebf8",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231110202835.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "27c44562fc9d29fa1e711b619c4c5880e80c5ef8"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```