### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20231110210629.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:052719dda5e9b92ff570aff8b3ca2a11bb5588699246dd4a49dab7af4d2b9101
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20231110210629.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 408c34a042760fc135d08bef62d927c8ec5e4502
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:052719dda5e9b92ff570aff8b3ca2a11bb5588699246dd4a49dab7af4d2b9101",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231110210629.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "408c34a042760fc135d08bef62d927c8ec5e4502"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:052719dda5e9b92ff570aff8b3ca2a11bb5588699246dd4a49dab7af4d2b9101",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231110210629.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "408c34a042760fc135d08bef62d927c8ec5e4502"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```