### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20231113182424.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:fe953e1bff4bc96bfb33b7880b59a515e7ecea62d0c48aeee17e55a5bd868772
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20231113182424.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 7b1db17df4acc7b57e935ef96c87cea9aea2e4eb
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fe953e1bff4bc96bfb33b7880b59a515e7ecea62d0c48aeee17e55a5bd868772",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231113182424.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "7b1db17df4acc7b57e935ef96c87cea9aea2e4eb"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fe953e1bff4bc96bfb33b7880b59a515e7ecea62d0c48aeee17e55a5bd868772",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231113182424.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "7b1db17df4acc7b57e935ef96c87cea9aea2e4eb"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```