### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231113193837.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:5a146858ce42263edeeb4c15bdb9e123d20c24816edfb2010718dc72e8a7e7c7
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231113193837.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: c90e3e3b1b0b617518e1c7786c6e35f4af633f6e
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5a146858ce42263edeeb4c15bdb9e123d20c24816edfb2010718dc72e8a7e7c7",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231113193837.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "c90e3e3b1b0b617518e1c7786c6e35f4af633f6e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5a146858ce42263edeeb4c15bdb9e123d20c24816edfb2010718dc72e8a7e7c7",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231113193837.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "c90e3e3b1b0b617518e1c7786c6e35f4af633f6e"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```