### PR TITLE
chore(cd): update deck-armory version to 2023.11.14.10.41.45.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:28069f6e5f605f38dd050ba650659b4455a332d2dd6f63fa9776310583cece66
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2023.11.14.10.41.45.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: 611c9ec066b38a6d95b489d805b17168c4c62a9a
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "73dda48caccd969ef562af3f86bc1f17efbdad7f"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:28069f6e5f605f38dd050ba650659b4455a332d2dd6f63fa9776310583cece66",
        "repository": "armory/deck-armory",
        "tag": "2023.11.14.10.41.45.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "611c9ec066b38a6d95b489d805b17168c4c62a9a"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "73dda48caccd969ef562af3f86bc1f17efbdad7f"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:28069f6e5f605f38dd050ba650659b4455a332d2dd6f63fa9776310583cece66",
        "repository": "armory/deck-armory",
        "tag": "2023.11.14.10.41.45.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "611c9ec066b38a6d95b489d805b17168c4c62a9a"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```