### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20231114212917.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:5d1778aea973901a185b31db1c968ef559a2fa980830f824a328c4ec98bf9e9f
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20231114212917.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: b17042dedad2944b854f97558eaadf3bbfc8f6f7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5d1778aea973901a185b31db1c968ef559a2fa980830f824a328c4ec98bf9e9f",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231114212917.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "b17042dedad2944b854f97558eaadf3bbfc8f6f7"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5d1778aea973901a185b31db1c968ef559a2fa980830f824a328c4ec98bf9e9f",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231114212917.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "b17042dedad2944b854f97558eaadf3bbfc8f6f7"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```