### PR TITLE
chore(cd): update armory-ext version to 2023.11.15.13.34.21.master

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -1,12 +1,12 @@
 plugins:
   armory-ext:
     image:
-      imageId: sha256:d34ea6f29026233a69433ca689f21c1975db87652a9cb7308d53837f9ed979b3
+      imageId: sha256:2119ecfe0e43c0b005c6c0d6d56859b24315caee22628b2ef7b8c6abd7b87430
       repository: armory/armory-ext
-      tag: 2022.11.14.23.26.42.master
+      tag: 2023.11.15.13.34.21.master
     vcs:
       repo:
         orgName: armory-plugins
         repoName: armory-ext
         type: github
-      sha: 3a0dc6c3f1fec593cd429e5ca9056d521424ff2c
+      sha: 41e2b8cafc0d79779acf8551c0faa593a9d4d5bc


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2119ecfe0e43c0b005c6c0d6d56859b24315caee22628b2ef7b8c6abd7b87430",
        "repository": "armory/armory-ext",
        "tag": "2023.11.15.13.34.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-plugins",
          "repoName": "armory-ext",
          "type": "github"
        },
        "sha": "41e2b8cafc0d79779acf8551c0faa593a9d4d5bc"
      }
    },
    "name": "armory-ext"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2119ecfe0e43c0b005c6c0d6d56859b24315caee22628b2ef7b8c6abd7b87430",
        "repository": "armory/armory-ext",
        "tag": "2023.11.15.13.34.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-plugins",
          "repoName": "armory-ext",
          "type": "github"
        },
        "sha": "41e2b8cafc0d79779acf8551c0faa593a9d4d5bc"
      }
    },
    "name": "armory-ext"
  },
  "stackFile": "plugins.yml",
  "stackPath": "plugins"
}
```