### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231116170359.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:c8170d03ab86253adb26873b21557c29e11741969a74f0102935b7ec523bb89d
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231116170359.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 01718c32020f3f3271132e7f224003b135a984ff
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c8170d03ab86253adb26873b21557c29e11741969a74f0102935b7ec523bb89d",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231116170359.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "01718c32020f3f3271132e7f224003b135a984ff"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c8170d03ab86253adb26873b21557c29e11741969a74f0102935b7ec523bb89d",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231116170359.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "01718c32020f3f3271132e7f224003b135a984ff"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```