### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20231120175121.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:053d281a3264bc11c28ae631faee8339e1431679340085f6d81c8f2c252bc236
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20231120175121.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 4b40a26189d6c8d824c207635f0143137cefaeaa
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:053d281a3264bc11c28ae631faee8339e1431679340085f6d81c8f2c252bc236",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231120175121.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "4b40a26189d6c8d824c207635f0143137cefaeaa"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:053d281a3264bc11c28ae631faee8339e1431679340085f6d81c8f2c252bc236",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231120175121.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "4b40a26189d6c8d824c207635f0143137cefaeaa"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```