### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231120182424.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:5bdb5749a3c8d9b31dbb615621adc23cbed3ae789a3121bdb6e2f9ea67860cef
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231120182424.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: f5dfbbbb60a8ae6fa65c27fcada8e54e51e1737c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5bdb5749a3c8d9b31dbb615621adc23cbed3ae789a3121bdb6e2f9ea67860cef",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231120182424.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "f5dfbbbb60a8ae6fa65c27fcada8e54e51e1737c"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5bdb5749a3c8d9b31dbb615621adc23cbed3ae789a3121bdb6e2f9ea67860cef",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231120182424.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "f5dfbbbb60a8ae6fa65c27fcada8e54e51e1737c"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```