### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20231121195327.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:fa5cf7b5b6175cfe5582fc5182cd18aaf9559e3b692f042f3aeec2774b3b3df3
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20231121195327.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 37835ea4767501cd9d0b0d6176d8803762873268
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fa5cf7b5b6175cfe5582fc5182cd18aaf9559e3b692f042f3aeec2774b3b3df3",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231121195327.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "37835ea4767501cd9d0b0d6176d8803762873268"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:fa5cf7b5b6175cfe5582fc5182cd18aaf9559e3b692f042f3aeec2774b3b3df3",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231121195327.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "37835ea4767501cd9d0b0d6176d8803762873268"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```