### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20231122000506.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:495ee98a1e1ecf0208170c954dde1016213facb633e0ae287e10d5382acdc7bf
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20231122000506.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: 7d7b8196d0f2bac5446dc1f6fc3b35629e0cfd64
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:495ee98a1e1ecf0208170c954dde1016213facb633e0ae287e10d5382acdc7bf",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231122000506.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "7d7b8196d0f2bac5446dc1f6fc3b35629e0cfd64"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:495ee98a1e1ecf0208170c954dde1016213facb633e0ae287e10d5382acdc7bf",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231122000506.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "7d7b8196d0f2bac5446dc1f6fc3b35629e0cfd64"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```