### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20231122005343.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:7ccd919bca7f8f904bf6a1752a5bbe14eef5a375ed789499106fa9c51a5dde94
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20231122005343.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: 3947a1bcc9890046bd82483a2ce58986b6d4906f
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7ccd919bca7f8f904bf6a1752a5bbe14eef5a375ed789499106fa9c51a5dde94",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231122005343.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "3947a1bcc9890046bd82483a2ce58986b6d4906f"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7ccd919bca7f8f904bf6a1752a5bbe14eef5a375ed789499106fa9c51a5dde94",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231122005343.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "3947a1bcc9890046bd82483a2ce58986b6d4906f"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```