### PR TITLE
chore(cd): update armory-ext version to 2023.11.22.18.44.36.master

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -1,12 +1,12 @@
 plugins:
   armory-ext:
     image:
-      imageId: sha256:d34ea6f29026233a69433ca689f21c1975db87652a9cb7308d53837f9ed979b3
+      imageId: sha256:a59ecceb51a46490cbc7ba689196df0656313a675631b7b946a5da75f96ee606
       repository: armory/armory-ext
-      tag: 2022.11.14.23.26.42.master
+      tag: 2023.11.22.18.44.36.master
     vcs:
       repo:
         orgName: armory-plugins
         repoName: armory-ext
         type: github
-      sha: 3a0dc6c3f1fec593cd429e5ca9056d521424ff2c
+      sha: 3ca91d1a68a96ec5d4982d2d0958e4f8e1845bb9


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a59ecceb51a46490cbc7ba689196df0656313a675631b7b946a5da75f96ee606",
        "repository": "armory/armory-ext",
        "tag": "2023.11.22.18.44.36.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-plugins",
          "repoName": "armory-ext",
          "type": "github"
        },
        "sha": "3ca91d1a68a96ec5d4982d2d0958e4f8e1845bb9"
      }
    },
    "name": "armory-ext"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a59ecceb51a46490cbc7ba689196df0656313a675631b7b946a5da75f96ee606",
        "repository": "armory/armory-ext",
        "tag": "2023.11.22.18.44.36.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-plugins",
          "repoName": "armory-ext",
          "type": "github"
        },
        "sha": "3ca91d1a68a96ec5d4982d2d0958e4f8e1845bb9"
      }
    },
    "name": "armory-ext"
  },
  "stackFile": "plugins.yml",
  "stackPath": "plugins"
}
```