### PR TITLE
chore(cd): update armory-ext version to 2023.11.23.14.55.34.master

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -1,12 +1,12 @@
 plugins:
   armory-ext:
     image:
-      imageId: sha256:d34ea6f29026233a69433ca689f21c1975db87652a9cb7308d53837f9ed979b3
+      imageId: sha256:eb289dc8b0292e93f94b0e58309980d66e359938799c40526aeb2a31346d9c20
       repository: armory/armory-ext
-      tag: 2022.11.14.23.26.42.master
+      tag: 2023.11.23.14.55.34.master
     vcs:
       repo:
         orgName: armory-plugins
         repoName: armory-ext
         type: github
-      sha: 3a0dc6c3f1fec593cd429e5ca9056d521424ff2c
+      sha: e909d822dbfe871f76d2ea3ff76c720710983222


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:eb289dc8b0292e93f94b0e58309980d66e359938799c40526aeb2a31346d9c20",
        "repository": "armory/armory-ext",
        "tag": "2023.11.23.14.55.34.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-plugins",
          "repoName": "armory-ext",
          "type": "github"
        },
        "sha": "e909d822dbfe871f76d2ea3ff76c720710983222"
      }
    },
    "name": "armory-ext"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:eb289dc8b0292e93f94b0e58309980d66e359938799c40526aeb2a31346d9c20",
        "repository": "armory/armory-ext",
        "tag": "2023.11.23.14.55.34.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-plugins",
          "repoName": "armory-ext",
          "type": "github"
        },
        "sha": "e909d822dbfe871f76d2ea3ff76c720710983222"
      }
    },
    "name": "armory-ext"
  },
  "stackFile": "plugins.yml",
  "stackPath": "plugins"
}
```