### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20231128172044.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:2a850549b0e2d9f050b096d10eead58aed045eacf3569cbf824576a944a26569
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20231128172044.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 495c619ad96c98201d4bff4c15a2443959f6187a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2a850549b0e2d9f050b096d10eead58aed045eacf3569cbf824576a944a26569",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231128172044.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "495c619ad96c98201d4bff4c15a2443959f6187a"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2a850549b0e2d9f050b096d10eead58aed045eacf3569cbf824576a944a26569",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231128172044.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "495c619ad96c98201d4bff4c15a2443959f6187a"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```