### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231128175530.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:d792a468a7f9310928d166476caabec3e398369e8c2954249ac558ba7c47f145
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231128175530.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: a89b0988724414b77fbf0d60834d46158953bfa8
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d792a468a7f9310928d166476caabec3e398369e8c2954249ac558ba7c47f145",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231128175530.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "a89b0988724414b77fbf0d60834d46158953bfa8"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d792a468a7f9310928d166476caabec3e398369e8c2954249ac558ba7c47f145",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231128175530.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "a89b0988724414b77fbf0d60834d46158953bfa8"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```