### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20231128223428.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:55a19c94cba0784fc5ccf3271a3d3255884fa0f01ff9d0245e4e62a46b633a8c
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20231128223428.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 4a17a5ca0ad84bbda1bec6a1481c393f2b238a5f
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:55a19c94cba0784fc5ccf3271a3d3255884fa0f01ff9d0245e4e62a46b633a8c",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231128223428.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "4a17a5ca0ad84bbda1bec6a1481c393f2b238a5f"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:55a19c94cba0784fc5ccf3271a3d3255884fa0f01ff9d0245e4e62a46b633a8c",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231128223428.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "4a17a5ca0ad84bbda1bec6a1481c393f2b238a5f"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```