### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231129210430.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:07e63b524eac1c8d98c4328a489dc2cf1f658104f5d17ebcf6e7b3f02312ca7a
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231129210430.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 738e5eda0fc501dcf9c226e699960d48a912a1b7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:07e63b524eac1c8d98c4328a489dc2cf1f658104f5d17ebcf6e7b3f02312ca7a",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231129210430.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "738e5eda0fc501dcf9c226e699960d48a912a1b7"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:07e63b524eac1c8d98c4328a489dc2cf1f658104f5d17ebcf6e7b3f02312ca7a",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231129210430.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "738e5eda0fc501dcf9c226e699960d48a912a1b7"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```