### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20231201095855.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:5a80cba5ebed9f585418071ca6feb4eac949707ee4a1da7dded8757151d2ad15
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20231201095855.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 13455b4cd7b5986724f8d3f36d906c7f17795b00
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5a80cba5ebed9f585418071ca6feb4eac949707ee4a1da7dded8757151d2ad15",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231201095855.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "13455b4cd7b5986724f8d3f36d906c7f17795b00"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5a80cba5ebed9f585418071ca6feb4eac949707ee4a1da7dded8757151d2ad15",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231201095855.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "13455b4cd7b5986724f8d3f36d906c7f17795b00"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```