### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20231201095622.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:e9fe6597930e44b6109b450097e842f1609cefe66100c0af3368a66f3dcf1776
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20231201095622.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: ff66cc31de7b4ab647306de910d09bcd66c97426
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e9fe6597930e44b6109b450097e842f1609cefe66100c0af3368a66f3dcf1776",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231201095622.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "ff66cc31de7b4ab647306de910d09bcd66c97426"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e9fe6597930e44b6109b450097e842f1609cefe66100c0af3368a66f3dcf1776",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231201095622.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "ff66cc31de7b4ab647306de910d09bcd66c97426"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```