### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20231201095748.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:ba9f9b66ff7a948c9ee9a3e32f4b369bb4f2e86f303a68d535c836fe074b3c8e
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20231201095748.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: b83c9c459db0855610acaf8dc1daa7df3790d5ef
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ba9f9b66ff7a948c9ee9a3e32f4b369bb4f2e86f303a68d535c836fe074b3c8e",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231201095748.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "b83c9c459db0855610acaf8dc1daa7df3790d5ef"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ba9f9b66ff7a948c9ee9a3e32f4b369bb4f2e86f303a68d535c836fe074b3c8e",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231201095748.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "b83c9c459db0855610acaf8dc1daa7df3790d5ef"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```