### PR TITLE
chore(cd): update spinnaker-kayenta version to 2023.0.0-20231201095652.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-kayenta:
+    image:
+      imageId: sha256:bb4b99d7d85ddf6be5d1ed50e39c0fef1f9c081e93b2c01888780c05609cb383
+      repository: armory/spinnaker-kayenta
+      tag: 2023.0.0-20231201095652.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: kayenta
+        type: github
+      sha: 37fb5dd33cb01eb3f8236b0a6b19abfc76ebde6c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:bb4b99d7d85ddf6be5d1ed50e39c0fef1f9c081e93b2c01888780c05609cb383",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2023.0.0-20231201095652.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "37fb5dd33cb01eb3f8236b0a6b19abfc76ebde6c"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:bb4b99d7d85ddf6be5d1ed50e39c0fef1f9c081e93b2c01888780c05609cb383",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2023.0.0-20231201095652.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "37fb5dd33cb01eb3f8236b0a6b19abfc76ebde6c"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```