### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231201100206.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:87f0872afe949470f9abd76c97f72c349195df5b86cd8b56f3d94d4eb95c667d
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231201100206.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 863e5d609aea9115b3be242d83a266243e08ad4a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:87f0872afe949470f9abd76c97f72c349195df5b86cd8b56f3d94d4eb95c667d",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231201100206.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "863e5d609aea9115b3be242d83a266243e08ad4a"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:87f0872afe949470f9abd76c97f72c349195df5b86cd8b56f3d94d4eb95c667d",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231201100206.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "863e5d609aea9115b3be242d83a266243e08ad4a"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```