### PR TITLE
chore(cd): update deck-armory version to 2023.12.01.10.45.58.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:f3a628559c8c6f59ed9bb75269dbdbce31af18764b2a906a15cfe4aaf06b7f9f
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2023.12.01.10.45.58.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: 622e5f6ab507f68a41a85bbaf46e4391b002e133
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "9bd9b014c31ea5ee78e24cd3f85f266e6e47d2cc"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:f3a628559c8c6f59ed9bb75269dbdbce31af18764b2a906a15cfe4aaf06b7f9f",
        "repository": "armory/deck-armory",
        "tag": "2023.12.01.10.45.58.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "622e5f6ab507f68a41a85bbaf46e4391b002e133"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "9bd9b014c31ea5ee78e24cd3f85f266e6e47d2cc"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:f3a628559c8c6f59ed9bb75269dbdbce31af18764b2a906a15cfe4aaf06b7f9f",
        "repository": "armory/deck-armory",
        "tag": "2023.12.01.10.45.58.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "622e5f6ab507f68a41a85bbaf46e4391b002e133"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```