### PR TITLE
chore(cd): update spinnaker-orca version to 2023.0.0-20231201150658.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:80f87880fabf0bc225a00200fa2ff5e9a9ab2f07a8f66d477c26ed8e8305d512
+      repository: armory/spinnaker-orca
+      tag: 2023.0.0-20231201150658.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: 6207d54324ce45b8e175769bf49ebeb3032b1dfb
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:80f87880fabf0bc225a00200fa2ff5e9a9ab2f07a8f66d477c26ed8e8305d512",
        "repository": "armory/spinnaker-orca",
        "tag": "2023.0.0-20231201150658.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "6207d54324ce45b8e175769bf49ebeb3032b1dfb"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:80f87880fabf0bc225a00200fa2ff5e9a9ab2f07a8f66d477c26ed8e8305d512",
        "repository": "armory/spinnaker-orca",
        "tag": "2023.0.0-20231201150658.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "6207d54324ce45b8e175769bf49ebeb3032b1dfb"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```