### PR TITLE
chore(cd): update spinnaker-fiat version to 2023.0.0-20231201160954.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:264221c799808f2ae5c20a59de582f752874a294cf9fe1c5a36f86bb119fd5b0
+      repository: armory/spinnaker-fiat
+      tag: 2023.0.0-20231201160954.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: b450064b3093aa0dfe9b9621035f1cacedbc22b3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:264221c799808f2ae5c20a59de582f752874a294cf9fe1c5a36f86bb119fd5b0",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231201160954.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "b450064b3093aa0dfe9b9621035f1cacedbc22b3"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:264221c799808f2ae5c20a59de582f752874a294cf9fe1c5a36f86bb119fd5b0",
        "repository": "armory/spinnaker-fiat",
        "tag": "2023.0.0-20231201160954.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "b450064b3093aa0dfe9b9621035f1cacedbc22b3"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```