### PR TITLE
chore(cd): update spinnaker-kayenta version to 2023.0.0-20231201162919.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-kayenta:
+    image:
+      imageId: sha256:b2adf1b3a08847b25a8d06196aa5329cc3af8b5c596c4100851aa68c8452513e
+      repository: armory/spinnaker-kayenta
+      tag: 2023.0.0-20231201162919.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: kayenta
+        type: github
+      sha: 00c750de225828a10fcd5120ec3391877aafe728
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b2adf1b3a08847b25a8d06196aa5329cc3af8b5c596c4100851aa68c8452513e",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2023.0.0-20231201162919.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "00c750de225828a10fcd5120ec3391877aafe728"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b2adf1b3a08847b25a8d06196aa5329cc3af8b5c596c4100851aa68c8452513e",
        "repository": "armory/spinnaker-kayenta",
        "tag": "2023.0.0-20231201162919.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "kayenta",
          "type": "github"
        },
        "sha": "00c750de225828a10fcd5120ec3391877aafe728"
      }
    },
    "name": "spinnaker-kayenta"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```