### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231201170746.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:bb35b8aa4eebaf0655a18d52c6bbe191cb430eb4141f8aa980463df8ee93898a
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231201170746.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 2143139f906e1be9e12c2f768c14b140061eb580
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:bb35b8aa4eebaf0655a18d52c6bbe191cb430eb4141f8aa980463df8ee93898a",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231201170746.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "2143139f906e1be9e12c2f768c14b140061eb580"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:bb35b8aa4eebaf0655a18d52c6bbe191cb430eb4141f8aa980463df8ee93898a",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231201170746.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "2143139f906e1be9e12c2f768c14b140061eb580"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```