### PR TITLE
chore(cd): update spinnaker-rosco version to 2023.0.0-20231201173658.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-rosco:
+    image:
+      imageId: sha256:ab92eec253e775934d4f9b70a600ae852376abd027b780e15e508d816083776a
+      repository: armory/spinnaker-rosco
+      tag: 2023.0.0-20231201173658.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: rosco
+        type: github
+      sha: 6147e3f778f00102b1239d0437514154ff5f4ce3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ab92eec253e775934d4f9b70a600ae852376abd027b780e15e508d816083776a",
        "repository": "armory/spinnaker-rosco",
        "tag": "2023.0.0-20231201173658.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "6147e3f778f00102b1239d0437514154ff5f4ce3"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ab92eec253e775934d4f9b70a600ae852376abd027b780e15e508d816083776a",
        "repository": "armory/spinnaker-rosco",
        "tag": "2023.0.0-20231201173658.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "rosco",
          "type": "github"
        },
        "sha": "6147e3f778f00102b1239d0437514154ff5f4ce3"
      }
    },
    "name": "spinnaker-rosco"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```