### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2023.0.0-20231201213200.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:11eeee0f7cd38570b55d7de98b282f95da5a0679928f17f0341f8b5506b33013
+      repository: armory/spinnaker-clouddriver
+      tag: 2023.0.0-20231201213200.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: ad5f5f8cb30a6a90751f088e25e534cf82921cc5
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:11eeee0f7cd38570b55d7de98b282f95da5a0679928f17f0341f8b5506b33013",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231201213200.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "ad5f5f8cb30a6a90751f088e25e534cf82921cc5"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:11eeee0f7cd38570b55d7de98b282f95da5a0679928f17f0341f8b5506b33013",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2023.0.0-20231201213200.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "ad5f5f8cb30a6a90751f088e25e534cf82921cc5"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```