### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20231201235224.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:411f8c8223bbf2c19124f355f1067027d7c8e1113c2be7dc49f2113fcd14035e
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20231201235224.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: 54bf338cd146ab6e623b9553fc0b418da8144a1c
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:411f8c8223bbf2c19124f355f1067027d7c8e1113c2be7dc49f2113fcd14035e",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231201235224.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "54bf338cd146ab6e623b9553fc0b418da8144a1c"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:411f8c8223bbf2c19124f355f1067027d7c8e1113c2be7dc49f2113fcd14035e",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231201235224.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "54bf338cd146ab6e623b9553fc0b418da8144a1c"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```