### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20231205213654.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:0a4e200333017382db1c46ad7699eb2525afe58b5cd027fb58f95f7db7112245
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20231205213654.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 104666d97b76047a509d5ca283d294d788a7c4c8
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:0a4e200333017382db1c46ad7699eb2525afe58b5cd027fb58f95f7db7112245",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231205213654.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "104666d97b76047a509d5ca283d294d788a7c4c8"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:0a4e200333017382db1c46ad7699eb2525afe58b5cd027fb58f95f7db7112245",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231205213654.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "104666d97b76047a509d5ca283d294d788a7c4c8"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```