### PR TITLE
chore(cd): update spinnaker-gate version to 2023.0.0-20231205213615.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:b123feab69695954c5e65fa57da8d3739153ef8210560b39b023e92d611843dd
+      repository: armory/spinnaker-gate
+      tag: 2023.0.0-20231205213615.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: db11a65fbf2ba26daae6c08e25f541d295dd9691
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b123feab69695954c5e65fa57da8d3739153ef8210560b39b023e92d611843dd",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231205213615.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "db11a65fbf2ba26daae6c08e25f541d295dd9691"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b123feab69695954c5e65fa57da8d3739153ef8210560b39b023e92d611843dd",
        "repository": "armory/spinnaker-gate",
        "tag": "2023.0.0-20231205213615.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "db11a65fbf2ba26daae6c08e25f541d295dd9691"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```