### PR TITLE
chore(cd): update deck-armory version to 2023.12.07.10.34.25.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:543495cb2cf615be55b46d728b87c0f6e5b2334936cba50c0488b3c1bbc4e475
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2023.12.07.10.34.25.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: 47edf2f239a489e5cf76060e7daf520cefd427c1
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "3064f852a9bd2713c6435f789cc23a116807e31b"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:543495cb2cf615be55b46d728b87c0f6e5b2334936cba50c0488b3c1bbc4e475",
        "repository": "armory/deck-armory",
        "tag": "2023.12.07.10.34.25.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "47edf2f239a489e5cf76060e7daf520cefd427c1"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "3064f852a9bd2713c6435f789cc23a116807e31b"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:543495cb2cf615be55b46d728b87c0f6e5b2334936cba50c0488b3c1bbc4e475",
        "repository": "armory/deck-armory",
        "tag": "2023.12.07.10.34.25.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "47edf2f239a489e5cf76060e7daf520cefd427c1"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```