### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20231212095939.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:9df413094bfa2b21a4726b13834d30df236c12561dec4011ed4bee260351e116
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20231212095939.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 953c35d66ac3dcd977bbf9742281610fdce18258
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:9df413094bfa2b21a4726b13834d30df236c12561dec4011ed4bee260351e116",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231212095939.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "953c35d66ac3dcd977bbf9742281610fdce18258"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:9df413094bfa2b21a4726b13834d30df236c12561dec4011ed4bee260351e116",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231212095939.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "953c35d66ac3dcd977bbf9742281610fdce18258"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```