### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20231212095908.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:584f143e75276e2d63d73c4db089f0a7bd6ba7eae58031e5390d71c28b42a7f8
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20231212095908.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: a282939c8c96a9e61461b2abfafb15e66fff7616
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:584f143e75276e2d63d73c4db089f0a7bd6ba7eae58031e5390d71c28b42a7f8",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231212095908.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "a282939c8c96a9e61461b2abfafb15e66fff7616"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:584f143e75276e2d63d73c4db089f0a7bd6ba7eae58031e5390d71c28b42a7f8",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231212095908.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "a282939c8c96a9e61461b2abfafb15e66fff7616"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```