### PR TITLE
chore(cd): update deck-armory version to 2023.12.21.03.49.28.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:26233863d8203a2d5f425fc5e71ccc3050b151b23d86702a6f50004c63ebd985
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2023.12.21.03.49.28.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: 8673bef289d67fe4ec743e059e6f5a21fd160c11
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "20d6ca89f39a5f44a802a1ccaffd669587450d76"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:26233863d8203a2d5f425fc5e71ccc3050b151b23d86702a6f50004c63ebd985",
        "repository": "armory/deck-armory",
        "tag": "2023.12.21.03.49.28.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "8673bef289d67fe4ec743e059e6f5a21fd160c11"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "20d6ca89f39a5f44a802a1ccaffd669587450d76"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:26233863d8203a2d5f425fc5e71ccc3050b151b23d86702a6f50004c63ebd985",
        "repository": "armory/deck-armory",
        "tag": "2023.12.21.03.49.28.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "8673bef289d67fe4ec743e059e6f5a21fd160c11"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```