### PR TITLE
chore(cd): update spinnaker-echo version to 2023.0.0-20231222170025.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:740753fb95491db639c66a5ea85a876ec6439f56e70fa10d4775c08e4cd7c224
+      repository: armory/spinnaker-echo
+      tag: 2023.0.0-20231222170025.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 18d038db6016233c999ccc24cd4dfd3e1debbd6a
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:740753fb95491db639c66a5ea85a876ec6439f56e70fa10d4775c08e4cd7c224",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231222170025.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "18d038db6016233c999ccc24cd4dfd3e1debbd6a"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:740753fb95491db639c66a5ea85a876ec6439f56e70fa10d4775c08e4cd7c224",
        "repository": "armory/spinnaker-echo",
        "tag": "2023.0.0-20231222170025.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "18d038db6016233c999ccc24cd4dfd3e1debbd6a"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```