### PR TITLE
chore(cd): update spinnaker-front50 version to 2023.0.0-20231223173944.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-front50:
+    image:
+      imageId: sha256:e55b05d1ceab254a0c43e30d394df4e288793942274b1b150221cf6460f8da55
+      repository: armory/spinnaker-front50
+      tag: 2023.0.0-20231223173944.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: front50
+        type: github
+      sha: eec0005f42df41283d4d0ef94d143ca43ab896a3
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e55b05d1ceab254a0c43e30d394df4e288793942274b1b150221cf6460f8da55",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231223173944.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "eec0005f42df41283d4d0ef94d143ca43ab896a3"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:e55b05d1ceab254a0c43e30d394df4e288793942274b1b150221cf6460f8da55",
        "repository": "armory/spinnaker-front50",
        "tag": "2023.0.0-20231223173944.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "front50",
          "type": "github"
        },
        "sha": "eec0005f42df41283d4d0ef94d143ca43ab896a3"
      }
    },
    "name": "spinnaker-front50"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```