### PR TITLE
chore(cd): update deck-armory version to 2024.01.01.20.32.51.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -13,15 +13,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:19f689bf1763ebcd8e5ba27074f4748a5d801cdc37102a83c0b31bf55f8843ea
+      imageId: sha256:2802abe758a28082100ea4c455b49916494db8b1cd83741588e6a92566e5270a
       repository: armory/deck-armory
-      tag: 2022.08.15.20.12.08.master
+      tag: 2024.01.01.20.32.51.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 89f4744f1298326f951d56b4d5b7eef8186d80b9
+      sha: aa2a8ef8dbda67f5f5eba5e4c68249112ffb9aad
   dinghy:
     image:
       imageId: sha256:d8106551bb65f60b1eccb2b3c3b6ea44ca41f9c40e95a3a23132932d57034b0b


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:2802abe758a28082100ea4c455b49916494db8b1cd83741588e6a92566e5270a",
        "repository": "armory/deck-armory",
        "tag": "2024.01.01.20.32.51.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "aa2a8ef8dbda67f5f5eba5e4c68249112ffb9aad"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:2802abe758a28082100ea4c455b49916494db8b1cd83741588e6a92566e5270a",
        "repository": "armory/deck-armory",
        "tag": "2024.01.01.20.32.51.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "aa2a8ef8dbda67f5f5eba5e4c68249112ffb9aad"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```