### PR TITLE
chore(cd): update spinnaker-orca version to 2024.0.0-20240102190535.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:a3633a5b53743f83c26f0c27d43560f7d47a44f6fbafc968829665c4f0f221cd
+      repository: armory/spinnaker-orca
+      tag: 2024.0.0-20240102190535.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: 4ccba0d928422c014c999e20fb0f0792f21825a1
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a3633a5b53743f83c26f0c27d43560f7d47a44f6fbafc968829665c4f0f221cd",
        "repository": "armory/spinnaker-orca",
        "tag": "2024.0.0-20240102190535.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "4ccba0d928422c014c999e20fb0f0792f21825a1"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a3633a5b53743f83c26f0c27d43560f7d47a44f6fbafc968829665c4f0f221cd",
        "repository": "armory/spinnaker-orca",
        "tag": "2024.0.0-20240102190535.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "4ccba0d928422c014c999e20fb0f0792f21825a1"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```