### PR TITLE
chore(cd): update spinnaker-clouddriver version to 2024.0.0-20240102191240.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-clouddriver:
+    image:
+      imageId: sha256:922be3568aef7e97cc61e4c30618aa11c13c579eb66bf6c1c9bed39cadb9a74a
+      repository: armory/spinnaker-clouddriver
+      tag: 2024.0.0-20240102191240.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: clouddriver
+        type: github
+      sha: 9eb4ecdb89d787d8f593c7df4aa132a99f905ee4
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:922be3568aef7e97cc61e4c30618aa11c13c579eb66bf6c1c9bed39cadb9a74a",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2024.0.0-20240102191240.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "9eb4ecdb89d787d8f593c7df4aa132a99f905ee4"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:922be3568aef7e97cc61e4c30618aa11c13c579eb66bf6c1c9bed39cadb9a74a",
        "repository": "armory/spinnaker-clouddriver",
        "tag": "2024.0.0-20240102191240.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "clouddriver",
          "type": "github"
        },
        "sha": "9eb4ecdb89d787d8f593c7df4aa132a99f905ee4"
      }
    },
    "name": "spinnaker-clouddriver"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```