### PR TITLE
chore(cd): update terraformer version to 2024.01.29.14.46.59.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -123,12 +123,12 @@ services:
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
   terraformer:
     image:
-      imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a
+      imageId: sha256:1506ec5c67610640e8491759bb0dc4ab2d75375185616ec0d3b66758b8459cd5
       repository: armory/terraformer
-      tag: 2022.08.15.08.23.24.master
+      tag: 2024.01.29.14.46.59.master
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 06274aea2918f7e47222856537224de91c9cf542
+      sha: 3af8055b100be1c50162e2fa82dd5c4f99471225


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:1506ec5c67610640e8491759bb0dc4ab2d75375185616ec0d3b66758b8459cd5",
        "repository": "armory/terraformer",
        "tag": "2024.01.29.14.46.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "3af8055b100be1c50162e2fa82dd5c4f99471225"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:1506ec5c67610640e8491759bb0dc4ab2d75375185616ec0d3b66758b8459cd5",
        "repository": "armory/terraformer",
        "tag": "2024.01.29.14.46.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "3af8055b100be1c50162e2fa82dd5c4f99471225"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```