### PR TITLE
chore(cd): update spinnaker-orca version to 2024.0.0-20240201162527.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-orca:
+    image:
+      imageId: sha256:c59ce87a7acab47b94380c804e0db075a4b5d38c102b7c8bbf6c929eb1b972eb
+      repository: armory/spinnaker-orca
+      tag: 2024.0.0-20240201162527.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: orca
+        type: github
+      sha: c3528667ae353baa79e8cf75df0d3f66376aff88
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c59ce87a7acab47b94380c804e0db075a4b5d38c102b7c8bbf6c929eb1b972eb",
        "repository": "armory/spinnaker-orca",
        "tag": "2024.0.0-20240201162527.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "c3528667ae353baa79e8cf75df0d3f66376aff88"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c59ce87a7acab47b94380c804e0db075a4b5d38c102b7c8bbf6c929eb1b972eb",
        "repository": "armory/spinnaker-orca",
        "tag": "2024.0.0-20240201162527.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "orca",
          "type": "github"
        },
        "sha": "c3528667ae353baa79e8cf75df0d3f66376aff88"
      }
    },
    "name": "spinnaker-orca"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```