### PR TITLE
chore(cd): update terraformer version to 2024.02.08.08.58.59.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -123,12 +123,12 @@ services:
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
   terraformer:
     image:
-      imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a
+      imageId: sha256:c57279c6dfb0c64bd54bc77f759de32585e753ffe9da3886b787499f0ef2fd3b
       repository: armory/terraformer
-      tag: 2022.08.15.08.23.24.master
+      tag: 2024.02.08.08.58.59.master
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 06274aea2918f7e47222856537224de91c9cf542
+      sha: 7c3877386f561f76b3da9c7c16b85bda67c6e90d


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c57279c6dfb0c64bd54bc77f759de32585e753ffe9da3886b787499f0ef2fd3b",
        "repository": "armory/terraformer",
        "tag": "2024.02.08.08.58.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "7c3877386f561f76b3da9c7c16b85bda67c6e90d"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:c57279c6dfb0c64bd54bc77f759de32585e753ffe9da3886b787499f0ef2fd3b",
        "repository": "armory/terraformer",
        "tag": "2024.02.08.08.58.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "7c3877386f561f76b3da9c7c16b85bda67c6e90d"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```