### PR TITLE
chore(cd): update terraformer version to 2024.02.08.16.14.10.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -123,12 +123,12 @@ services:
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
   terraformer:
     image:
-      imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a
+      imageId: sha256:092f0fe5ee1ea1ba893d3733d9f932ba3463ce6866da0c836efb2fe5399e6ef7
       repository: armory/terraformer
-      tag: 2022.08.15.08.23.24.master
+      tag: 2024.02.08.16.14.10.master
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 06274aea2918f7e47222856537224de91c9cf542
+      sha: c18c1c5cdb6670fadeb3814d906ad99cabcfcac9


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:092f0fe5ee1ea1ba893d3733d9f932ba3463ce6866da0c836efb2fe5399e6ef7",
        "repository": "armory/terraformer",
        "tag": "2024.02.08.16.14.10.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "c18c1c5cdb6670fadeb3814d906ad99cabcfcac9"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:092f0fe5ee1ea1ba893d3733d9f932ba3463ce6866da0c836efb2fe5399e6ef7",
        "repository": "armory/terraformer",
        "tag": "2024.02.08.16.14.10.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "c18c1c5cdb6670fadeb3814d906ad99cabcfcac9"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```