### PR TITLE
chore(cd): update spinnaker-echo version to 2024.0.0-20240222171926.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:708ea381549b49b06dbe7076db6f3a2f9eb4037921c866a2e4dcb143b73500c3
+      repository: armory/spinnaker-echo
+      tag: 2024.0.0-20240222171926.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 47f78706fdf917c9c6b2e8aca2cf625b5e4055a7
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:708ea381549b49b06dbe7076db6f3a2f9eb4037921c866a2e4dcb143b73500c3",
        "repository": "armory/spinnaker-echo",
        "tag": "2024.0.0-20240222171926.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "47f78706fdf917c9c6b2e8aca2cf625b5e4055a7"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:708ea381549b49b06dbe7076db6f3a2f9eb4037921c866a2e4dcb143b73500c3",
        "repository": "armory/spinnaker-echo",
        "tag": "2024.0.0-20240222171926.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "47f78706fdf917c9c6b2e8aca2cf625b5e4055a7"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```