### PR TITLE
chore(cd): update spinnaker-fiat version to 2024.0.0-20240223174609.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-fiat:
+    image:
+      imageId: sha256:d338f0dcb08040d3acdc0dcb7c1056d08e015192bd680dd567f611998ae5b9d3
+      repository: armory/spinnaker-fiat
+      tag: 2024.0.0-20240223174609.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: fiat
+        type: github
+      sha: a33d2825fcbcff356d279488c1725a4568b124f5
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d338f0dcb08040d3acdc0dcb7c1056d08e015192bd680dd567f611998ae5b9d3",
        "repository": "armory/spinnaker-fiat",
        "tag": "2024.0.0-20240223174609.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "a33d2825fcbcff356d279488c1725a4568b124f5"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:d338f0dcb08040d3acdc0dcb7c1056d08e015192bd680dd567f611998ae5b9d3",
        "repository": "armory/spinnaker-fiat",
        "tag": "2024.0.0-20240223174609.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "fiat",
          "type": "github"
        },
        "sha": "a33d2825fcbcff356d279488c1725a4568b124f5"
      }
    },
    "name": "spinnaker-fiat"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```