### PR TITLE
chore(cd): update spinnaker-gate version to 2024.0.0-20240223174718.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-gate:
+    image:
+      imageId: sha256:7d1891f7e23560b31017d5fbc2cb3fa9422ee6b8bbc8f31795cc57ef3b21b566
+      repository: armory/spinnaker-gate
+      tag: 2024.0.0-20240223174718.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: gate
+        type: github
+      sha: bc9212b597584013456146ff3423dff987a6c130
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7d1891f7e23560b31017d5fbc2cb3fa9422ee6b8bbc8f31795cc57ef3b21b566",
        "repository": "armory/spinnaker-gate",
        "tag": "2024.0.0-20240223174718.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "bc9212b597584013456146ff3423dff987a6c130"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:7d1891f7e23560b31017d5fbc2cb3fa9422ee6b8bbc8f31795cc57ef3b21b566",
        "repository": "armory/spinnaker-gate",
        "tag": "2024.0.0-20240223174718.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "gate",
          "type": "github"
        },
        "sha": "bc9212b597584013456146ff3423dff987a6c130"
      }
    },
    "name": "spinnaker-gate"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```