### PR TITLE
chore(cd): update spinnaker-echo version to 2024.0.0-20240227052852.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:a2964dcbe763cb45f2eb4395a69f29da0a0e119d1740a03e3ae9061b72d91c25
+      repository: armory/spinnaker-echo
+      tag: 2024.0.0-20240227052852.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 5a85a7ee0ef38b99f4e12cdbb9c499a2ffe3a3ee
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a2964dcbe763cb45f2eb4395a69f29da0a0e119d1740a03e3ae9061b72d91c25",
        "repository": "armory/spinnaker-echo",
        "tag": "2024.0.0-20240227052852.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "5a85a7ee0ef38b99f4e12cdbb9c499a2ffe3a3ee"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a2964dcbe763cb45f2eb4395a69f29da0a0e119d1740a03e3ae9061b72d91c25",
        "repository": "armory/spinnaker-echo",
        "tag": "2024.0.0-20240227052852.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "5a85a7ee0ef38b99f4e12cdbb9c499a2ffe3a3ee"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```