### PR TITLE
chore(cd): update spinnaker-echo version to 2024.0.0-20240312162436.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:5608b91fc5d6567dfd71bf9fd8e591bfb400e6b934b761a1659939d9a22fce25
+      repository: armory/spinnaker-echo
+      tag: 2024.0.0-20240312162436.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 8325aef477445d49e52de8c8790e5e15891f5e2d
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5608b91fc5d6567dfd71bf9fd8e591bfb400e6b934b761a1659939d9a22fce25",
        "repository": "armory/spinnaker-echo",
        "tag": "2024.0.0-20240312162436.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "8325aef477445d49e52de8c8790e5e15891f5e2d"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:5608b91fc5d6567dfd71bf9fd8e591bfb400e6b934b761a1659939d9a22fce25",
        "repository": "armory/spinnaker-echo",
        "tag": "2024.0.0-20240312162436.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "8325aef477445d49e52de8c8790e5e15891f5e2d"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```