### PR TITLE
chore(cd): update spinnaker-echo version to 2024.0.0-20240312173550.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:f98ed8506d6b2f073182ae5b3698ef949b5cc3eb52fd773b8d684caeeaa48fab
+      repository: armory/spinnaker-echo
+      tag: 2024.0.0-20240312173550.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 671b5a2fdb6b0cc89e27545a97bd8143d154c521
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f98ed8506d6b2f073182ae5b3698ef949b5cc3eb52fd773b8d684caeeaa48fab",
        "repository": "armory/spinnaker-echo",
        "tag": "2024.0.0-20240312173550.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "671b5a2fdb6b0cc89e27545a97bd8143d154c521"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:f98ed8506d6b2f073182ae5b3698ef949b5cc3eb52fd773b8d684caeeaa48fab",
        "repository": "armory/spinnaker-echo",
        "tag": "2024.0.0-20240312173550.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "671b5a2fdb6b0cc89e27545a97bd8143d154c521"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```