### PR TITLE
chore(cd): update spinnaker-echo version to 2024.0.0-20240312200746.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -121,6 +121,17 @@ services:
         repoName: rosco
         type: github
       sha: ef1bab5e689e2542d0400027038af6442ec43f41
+  spinnaker-echo:
+    image:
+      imageId: sha256:a4fbe6ee1464dc41a155389044fa8c9c4a0b27ec77dbfac76369aa7b4636d366
+      repository: armory/spinnaker-echo
+      tag: 2024.0.0-20240312200746.master
+    vcs:
+      repo:
+        orgName: spinnaker
+        repoName: echo
+        type: github
+      sha: 59225abd93e873526cd47b89f67a330ba59a8aac
   terraformer:
     image:
       imageId: sha256:0d0ed4a42d4362f96caf4dc45814abaf1e858b5df1f972135f07e62f8f12df6a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a4fbe6ee1464dc41a155389044fa8c9c4a0b27ec77dbfac76369aa7b4636d366",
        "repository": "armory/spinnaker-echo",
        "tag": "2024.0.0-20240312200746.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "59225abd93e873526cd47b89f67a330ba59a8aac"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a4fbe6ee1464dc41a155389044fa8c9c4a0b27ec77dbfac76369aa7b4636d366",
        "repository": "armory/spinnaker-echo",
        "tag": "2024.0.0-20240312200746.master"
      },
      "vcs": {
        "repo": {
          "orgName": "spinnaker",
          "repoName": "echo",
          "type": "github"
        },
        "sha": "59225abd93e873526cd47b89f67a330ba59a8aac"
      }
    },
    "name": "spinnaker-echo"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```